### PR TITLE
WEBRTC-2522: When user log in with sip email address, it get log incorrect error

### DIFF
--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -149,7 +149,7 @@ const ClientOptions = () => {
                         />
                       </FormControl>
                       <FormDescription>
-                        Enter only your SIP username.
+                        Enter your SIP username.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>


### PR DESCRIPTION
## Description
This PR addresses the issue where users are getting an incorrect error message when trying to log in with their full SIP email address.

## Changes
- Updated the login input placeholder from 'example@sip.telnyx.com' to 'Username'
- Updated the form description to clarify that users should enter only their SIP username without the domain

## Jira Ticket
[WEBRTC-2522](https://telnyx.atlassian.net/browse/WEBRTC-2522)

## Testing
- Verified that the placeholder text now shows 'Username' instead of 'example@sip.telnyx.com'
- Verified that the form description now clearly indicates that users should enter only their SIP username without the domain

[WEBRTC-2522]: https://telnyx.atlassian.net/browse/WEBRTC-2522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ