### PR TITLE
WEBRTC-2648: Adding new regions to demo app for new voice sdk proxy regions

### DIFF
--- a/src/components/RegionSelect.tsx
+++ b/src/components/RegionSelect.tsx
@@ -16,7 +16,12 @@ const RegionSelect = () => {
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="auto">AUTO</SelectItem>
+        <SelectItem value="eu">EU</SelectItem>
+        <SelectItem value="us-central">US-CENTRAL</SelectItem>
+        <SelectItem value="us-east">US-EAST</SelectItem>
+        <SelectItem value="us-west">US-WEST</SelectItem>
         <SelectItem value="ca-central">CA-CENTRAL</SelectItem>
+        <SelectItem value="apac">APAC</SelectItem>
       </SelectContent>
     </Select>
   );


### PR DESCRIPTION
## WEBRTC-2648: Adding new regions to demo app for new voice sdk proxy regions

### Changes
- Added new regions to the RegionSelect.tsx component:
  - EU
  - US-CENTRAL
  - US-EAST
  - US-WEST
  - APAC
- Maintained CA-CENTRAL which was already present
- All region names are displayed in all capital letters as requested

### Testing
- The dropdown now includes all the required regions
- Region selection functionality remains unchanged

Jira: [WEBRTC-2648](https://telnyx.atlassian.net/browse/WEBRTC-2648)

[WEBRTC-2648]: https://telnyx.atlassian.net/browse/WEBRTC-2648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ