### PR TITLE
WEBRTC-2716: Removing Video Capabilities from JS Demo App

### DIFF
--- a/src/atoms/callOptions.ts
+++ b/src/atoms/callOptions.ts
@@ -20,7 +20,6 @@ export interface ICallOptions {
   debugOutput?: "socket" | "file";
   preferred_codecs?: RTCRtpCodec[];
   prefetchIceCandidates?: boolean;
-  video?: boolean;
 }
 
 const callOptionsAtom = atom({
@@ -34,7 +33,6 @@ const callOptionsAtom = atom({
   telnyxLegId: undefined,
   telnyxSessionId: undefined,
   useStereo: false,
-  video: false,
 } as ICallOptions);
 
 export const useCallOptions = () => useAtom(callOptionsAtom);

--- a/src/components/ActiveCall.tsx
+++ b/src/components/ActiveCall.tsx
@@ -20,30 +20,7 @@ type Props = {
   call: Call;
 };
 
-const VideoDisplay = ({ stream }: { stream: MediaStream }) => {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  useEffect(() => {
-    if (!stream) return;
-    if (!videoRef.current) return;
 
-    videoRef.current.srcObject = stream;
-  }, [stream]);
-
-  if (stream.getVideoTracks().length === 0) {
-    return null;
-  }
-  return (
-    <div className="w-[240px] h-[120px] rounded overflow-hidden border-white border-2">
-      <video
-        ref={videoRef}
-        autoPlay
-        muted
-        playsInline
-        className="w-full h-full object-cover"
-      />
-    </div>
-  );
-};
 
 const ActiveCall = ({ call }: Props) => {
   const onDTMFClick = useCallback(
@@ -74,11 +51,9 @@ const ActiveCall = ({ call }: Props) => {
 
         <div className="flex-1 max-h-[60vh] overflow-y-auto">
           <div className="flex flex-col space-y-4 items-center">
-            <VideoDisplay stream={call.remoteStream} />
             <h1>Inbound </h1>
             <AudioVisualizer mediaStream={call.remoteStream} />
 
-            <VideoDisplay stream={call.localStream} />
             <h1>Outbound</h1>
             <AudioVisualizer mediaStream={call.localStream} color="#fff" />
           </div>

--- a/src/components/CallOptions.tsx
+++ b/src/components/CallOptions.tsx
@@ -31,7 +31,6 @@ const CallOptions = () => {
     defaultValues: {
       callerName: "",
       destinationNumber: "",
-      video: false,
       callerNumber: "",
       clientState: "",
       customHeaders: [],
@@ -73,29 +72,7 @@ const CallOptions = () => {
       <CardContent>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-            <FormField
-              control={form.control}
-              name="video"
-              render={({ field }) => (
-                <FormItem className="flex items-center justify-between mb-4">
-                  <div>
-                    <FormLabel>Enable Video</FormLabel>
-                    <FormDescription>
-                      Enable Video Call (WebRTC To WebRTC only)
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      data-testid="checkbox-include-video"
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
 
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
 
             <FormField
               control={form.control}


### PR DESCRIPTION
## Description
This PR removes video capabilities from the WebRTC JS Demo App as requested in [WEBRTC-2716](https://telnyx.atlassian.net/browse/WEBRTC-2716).

## Changes
- Removed video toggle UI component from CallOptions.tsx
- Removed video option from application state in callOptions.ts
- Removed VideoDisplay component from ActiveCall.tsx
- Removed references to remote and local video streams in ActiveCall component

## Testing
The application should now function without any video capabilities, focusing only on audio calls.

[WEBRTC-2716]: https://telnyx.atlassian.net/browse/WEBRTC-2716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ