### PR TITLE
WEBRTC-2960: Fetch Telnyx SDK versions dynamically

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.11.0",
     "vite": "^5.4.10"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Summary
- fetch @telnyx/webrtc release metadata from the npm registry and sort by publication date
- populate the SDK version dropdown from the fetched list with a guarded fallback for offline cases
- persist the current selection in the list and add the Yarn 1.22 packageManager metadata

## Testing
- [ ] Not run (CI only)
