### PR TITLE
Fix: enableCallReports shows disabled and sends undefined on first connect

### DIFF
--- a/src/atoms/clientOptions.ts
+++ b/src/atoms/clientOptions.ts
@@ -1,6 +1,7 @@
+import { atomWithMergingStorage } from '@/lib/atomWithMergingStorage';
 import { IClientOptionsDemo } from '@/lib/types';
 import { useAtom } from 'jotai';
-import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+import { atomWithStorage } from 'jotai/utils';
 
 const clientOptionsDefault: IClientOptionsDemo = {
   debug: false,
@@ -17,30 +18,14 @@ const clientOptionsDefault: IClientOptionsDemo = {
   enableCallReports: true,
 };
 
-/**
- * Custom storage that merges stored values with the current defaults.
- * This ensures newly added fields (e.g. enableCallReports) are picked up
- * by existing users who already have a saved value in localStorage.
- */
-const mergingStorage = createJSONStorage<IClientOptionsDemo>(() => localStorage, {
-  reviver: (_key, value) => value,
-});
-const originalGetItem = mergingStorage.getItem.bind(mergingStorage);
-mergingStorage.getItem = (key, defaultValue) => {
-  const stored = originalGetItem(key, defaultValue);
-  if (stored === defaultValue) return defaultValue;
-  return { ...clientOptionsDefault, ...(stored as IClientOptionsDemo) };
-};
-
 const profilesAtom = atomWithStorage<IClientOptionsDemo[]>(
   'telnyx_client_profiles',
   [],
 );
 
-export const clientOptionsAtom = atomWithStorage<IClientOptionsDemo>(
+export const clientOptionsAtom = atomWithMergingStorage<IClientOptionsDemo>(
   'telnyx_client_options',
   clientOptionsDefault,
-  mergingStorage,
 );
 
 export const useClientOptions = () => useAtom(clientOptionsAtom);

--- a/src/atoms/clientOptions.ts
+++ b/src/atoms/clientOptions.ts
@@ -1,6 +1,36 @@
 import { IClientOptionsDemo } from '@/lib/types';
 import { useAtom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
+import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+
+const clientOptionsDefault: IClientOptionsDemo = {
+  debug: false,
+  debugOutput: 'socket',
+  login: '',
+  password: '',
+  login_token: '',
+  prefetchIceCandidates: false,
+  forceRelayCandidate: false,
+  trickleIce: false,
+  keepConnectionAliveOnSocketClose: false,
+  useCanaryRtcServer: false,
+  mutedMicOnStart: false,
+  enableCallReports: true,
+};
+
+/**
+ * Custom storage that merges stored values with the current defaults.
+ * This ensures newly added fields (e.g. enableCallReports) are picked up
+ * by existing users who already have a saved value in localStorage.
+ */
+const mergingStorage = createJSONStorage<IClientOptionsDemo>(() => localStorage, {
+  reviver: (_key, value) => value,
+});
+const originalGetItem = mergingStorage.getItem.bind(mergingStorage);
+mergingStorage.getItem = (key, defaultValue) => {
+  const stored = originalGetItem(key, defaultValue);
+  if (stored === defaultValue) return defaultValue;
+  return { ...clientOptionsDefault, ...(stored as IClientOptionsDemo) };
+};
 
 const profilesAtom = atomWithStorage<IClientOptionsDemo[]>(
   'telnyx_client_profiles',
@@ -9,20 +39,8 @@ const profilesAtom = atomWithStorage<IClientOptionsDemo[]>(
 
 export const clientOptionsAtom = atomWithStorage<IClientOptionsDemo>(
   'telnyx_client_options',
-  {
-    debug: false,
-    debugOutput: 'socket',
-    login: '',
-    password: '',
-    login_token: '',
-    prefetchIceCandidates: false,
-    forceRelayCandidate: false,
-    trickleIce: false,
-    keepConnectionAliveOnSocketClose: false,
-    useCanaryRtcServer: false,
-    mutedMicOnStart: false,
-    enableCallReports: true,
-  },
+  clientOptionsDefault,
+  mergingStorage,
 );
 
 export const useClientOptions = () => useAtom(clientOptionsAtom);

--- a/src/atoms/simpleUserCallOptions.ts
+++ b/src/atoms/simpleUserCallOptions.ts
@@ -1,13 +1,13 @@
+import { atomWithMergingStorage } from '@/lib/atomWithMergingStorage';
 import { ISimpleUserCallOptions } from '@/lib/types';
 import { useAtom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
 
 const defaultCallOptions: ISimpleUserCallOptions = {
   destinationNumber: '',
   extraHeaders: [],
 };
 
-const simpleUserCallOptionsAtom = atomWithStorage<ISimpleUserCallOptions>(
+const simpleUserCallOptionsAtom = atomWithMergingStorage<ISimpleUserCallOptions>(
   'telnyx_simple_user_call_options',
   defaultCallOptions,
 );

--- a/src/atoms/simpleUserClientOptions.ts
+++ b/src/atoms/simpleUserClientOptions.ts
@@ -1,6 +1,6 @@
+import { atomWithMergingStorage } from '@/lib/atomWithMergingStorage';
 import { TelnyxDeviceConfig } from '@telnyx/rtc-sipjs-simple-user';
 import { useAtom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
 
 const sipHost = import.meta.env.VITE_SIP_HOST || 'sip.telnyx.com';
 
@@ -14,10 +14,11 @@ const defaultSimpleUserOptions: TelnyxDeviceConfig = {
   registrarServer: `sip:${sipHost}:7443`,
 };
 
-export const simpleUserClientOptionsAtom = atomWithStorage<TelnyxDeviceConfig>(
-  'telnyx_simple_user_client_options',
-  defaultSimpleUserOptions,
-);
+export const simpleUserClientOptionsAtom =
+  atomWithMergingStorage<TelnyxDeviceConfig>(
+    'telnyx_simple_user_client_options',
+    defaultSimpleUserOptions,
+  );
 
 export const useSimpleUserClientOptions = () =>
   useAtom(simpleUserClientOptionsAtom);

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -89,6 +89,7 @@ const ClientOptions = () => {
       rtcIp: '',
       rtcPort: undefined,
       mutedMicOnStart: false,
+      enableCallReports: true,
       video: false,
       anonymous_login: {
         target_type: '',

--- a/src/lib/atomWithMergingStorage.ts
+++ b/src/lib/atomWithMergingStorage.ts
@@ -1,0 +1,28 @@
+import { atomWithStorage, createJSONStorage } from 'jotai/utils';
+
+/**
+ * Drop-in replacement for atomWithStorage for object-shaped atoms.
+ *
+ * atomWithStorage only uses its defaultValue when localStorage has no entry
+ * at all. Any stored object that was saved before a new field was added will
+ * be missing that field, causing it to be undefined at runtime.
+ *
+ * This wrapper shallow-merges the stored value with defaultValue on every
+ * read, so newly added fields always fall back to their defaults for existing
+ * users — no migration code required.
+ */
+export function atomWithMergingStorage<T extends object>(
+  key: string,
+  defaultValue: T,
+) {
+  const storage = createJSONStorage<T>(() => localStorage);
+  const originalGetItem = storage.getItem.bind(storage);
+
+  storage.getItem = (k, fallback) => {
+    const stored = originalGetItem(k, fallback);
+    if (stored === fallback) return fallback;
+    return { ...defaultValue, ...(stored as T) };
+  };
+
+  return atomWithStorage<T>(key, defaultValue, storage);
+}


### PR DESCRIPTION
## Problem

PR #65 added `enableCallReports: true` to the atom's `defaultValue`, but `atomWithStorage` only uses `defaultValue` when **no entry exists in `localStorage` at all**. Users who had previously saved client options get their stored object read back as-is — without the new `enableCallReports` key — so the field is `undefined`.

This causes two visible symptoms:
- The **Call Reports switch renders unchecked** (disabled), even though it should default to on
- On first connect, **`enableCallReports=undefined`** is passed to the SDK

## Fix

**1. Merging storage adapter** (`src/atoms/clientOptions.ts`)Wrap `atomWithStorage` with a custom storage that shallow-merges the stored object with `clientOptionsDefault` on every read. Any field missing from the stored value falls back to its default. This also protects against the same issue for any fields added in the future.

**2. `defaultValues` in `useForm`** (`src/components/ClientOptions.tsx`)Added `enableCallReports: true` to the form's `defaultValues` as a defence-in-depth measure.

## Testing

- `tsc --noEmit` passes clean
- Existing users: switch now shows **enabled** on load; `enableCallReports=true` sent on connect
- New users: no change in behaviour
- Toggling off, saving, and reloading: persists the `false` value correctly