### PR TITLE
feat: show beta/prerelease versions in widget version dropdown

### DIFF
--- a/src/components/AiAgentView.tsx
+++ b/src/components/AiAgentView.tsx
@@ -315,9 +315,7 @@ const AiAgentView = () => {
                           <SelectItem value="latest">Latest</SelectItem>
                           {availableVersions.map((version) => (
                             <SelectItem key={version} value={version}>
-                              {version.includes('-')
-                                ? `${version} 🧪`
-                                : version}
+                              {version.includes('-') ? `${version} 🧪` : version}
                             </SelectItem>
                           ))}
                         </SelectContent>


### PR DESCRIPTION
The widget version dropdown was filtering out all prerelease versions (`version.includes('-')`), hiding betas from the selector.

### Changes
- Remove the prerelease filter — only deprecated versions are excluded
- Prerelease versions show with a 🧪 marker in the dropdown
- Sort: stable versions first, then prereleases for the same semver tuple

### Why
We publish beta versions of `@telnyx/ai-agent-widget` for testing (e.g. `0.32.1-beta.0`) and need them selectable in the demo app.

Ref: WEBRTC-3324