### PR TITLE
feat: add Login button for in-place token refresh without socket reconnect

### DIFF
--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -682,6 +682,7 @@ const ClientOptions = () => {
               </Button>
             </div>
             <Button
+              type="button"
               data-testid="btn-login"
               variant="secondary"
               className="w-full"

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -657,27 +657,71 @@ const ClientOptions = () => {
               )}
             />
           </CardContent>
-          <CardFooter className="gap-2">
+          <CardFooter className="flex-col gap-2">
+            <div className="flex w-full gap-2">
+              <Button
+                data-testid="btn-connect"
+                onClick={form.handleSubmit(onSubmit)}
+                className="w-full"
+              >
+                {connectionStatus === 'connected' ? 'Reconnect' : 'Connect'}
+              </Button>
+              <Button
+                data-testid="btn-disconnect"
+                variant="destructive"
+                className="w-full"
+                disabled={connectionStatus === 'disconnected'}
+                onClick={() => {
+                  if (client) {
+                    client.disconnect();
+                  }
+                  setConnectionStatus('disconnected');
+                }}
+              >
+                Disconnect
+              </Button>
+            </div>
             <Button
-              data-testid="btn-connect"
-              onClick={form.handleSubmit(onSubmit)}
+              data-testid="btn-login"
+              variant="secondary"
               className="w-full"
-            >
-              {connectionStatus === 'connected' ? 'Reconnect' : 'Connect'}
-            </Button>
-            <Button
-              data-testid="btn-disconnect"
-              variant="destructive"
-              className="w-full"
-              disabled={connectionStatus === 'disconnected'}
+              disabled={connectionStatus !== 'registered'}
               onClick={() => {
-                if (client) {
-                  client.disconnect();
+                if (!client) return;
+
+                const values = form.getValues();
+                const creds: Record<string, unknown> = {};
+
+                if (values.login_token) {
+                  creds.login_token = values.login_token;
+                } else if (values.login && values.password) {
+                  creds.login = values.login;
+                  creds.password = values.password;
                 }
-                setConnectionStatus('disconnected');
+
+                client
+                  .login({
+                    creds,
+                    onSuccess: () => {
+                      toast.success(
+                        'Re-authenticated (socket kept alive)',
+                      );
+                      setConnectionStatus('registered');
+                    },
+                    onError: (error: unknown) => {
+                      toast.error(
+                        `Login failed: ${error instanceof Error ? error.message : String(error)}`,
+                      );
+                    },
+                  })
+                  .catch((error: unknown) => {
+                    toast.error(
+                      `Login error: ${error instanceof Error ? error.message : String(error)}`,
+                    );
+                  });
               }}
             >
-              Disconnect
+              Login (refresh token, no reconnect)
             </Button>
           </CardFooter>
         </form>

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -721,7 +721,7 @@ const ClientOptions = () => {
                   });
               }}
             >
-              Login (refresh token, no reconnect)
+              Login
             </Button>
           </CardFooter>
         </form>


### PR DESCRIPTION
## What

Adds a **Login** button to the client options card footer.

## Why

When clicking "Connect" multiple times, the demo app recreates the `TelnyxRTC` instance (Jotai atom re-derivation), which triggers `useEffect` cleanup → `client.disconnect()` → socket close → new `client.connect()`. This is the same pattern observed in customer integrations where the socket drops after every call.

The SDK's `client.login()` method (available since v2.25.17) re-authenticates on the **existing** WebSocket without requiring a full disconnect/reconnect cycle. This button exposes that capability in the demo app so engineers can:

1. **Test token refresh** — paste a new JWT and click Login to re-auth without dropping the socket
2. **Demonstrate the correct pattern** to customers who are unnecessarily doing disconnect+connect for credential updates

## How

- Calls `client.login({ creds })` with the current form values (JWT token or username/password)
- Button uses `type="button"` to prevent form submission (which would trigger `setClientOptions` → atom re-derivation → client recreation → socket close)
- Only enabled when client is already registered
- Shows success/error toast
- Zero socket disruption — verified in voice-sdk-proxy logs

## Docs

- [`client.login()` SDK reference](https://github.com/team-telnyx/webrtc/blob/main/packages/js/docs/ts/classes/TelnyxRTC.md#login)
