### PR TITLE
chore: bump @telnyx/webrtc from 2.25.22 to 2.25.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.25.22",
+    "@telnyx/webrtc": "2.25.24",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,10 +1210,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.25.22":
-  version "2.25.22"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.25.22.tgz#6a2f104dccec32d2c44f35917fffb5b76ca9156f"
-  integrity sha512-CQoI0kI20VWsro3sjdxDSrkL+QVcyORTN9mplOo3drTwML0AQUtHwz0nJc5W65mvuIsy+/yujO0HGmE+FBLfQw==
+"@telnyx/webrtc@2.25.24":
+  version "2.25.24"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.25.24.tgz#94a3dd862664938d8e2a1c8815694f53d13d00bd"
+  integrity sha512-fe1BfwrFnd4r2nrIO8UA/QsyBiN/rQQeveZXaOpUHVZZDcylMGsqvnXmlBXFZS4GaRv3JE38a4A5oCxYgNl+iA==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
Bumps `@telnyx/webrtc` from 2.25.22 to 2.25.24.

### Notable changes (since 2.25.22)

- feat: support `target_params` in anonymous login (WEBRTC-3324)
- feat: add audioLevel + transport stats to call report (WEBRTC-3321)
- feat: add ICE candidate pair stats to call report (WEBRTC-3302)
- fix: handle getUserMedia failure gracefully (no microphone)
- fix: retry once on network error when posting call report
- fix: send call reports for calls shorter than the collection interval
- fix: set direction before setState on inbound invite
- fix: use state-dependent hangup cause code
