### PR TITLE
feat: add singleInterfaceIce toggle

### DIFF
--- a/src/atoms/clientOptions.ts
+++ b/src/atoms/clientOptions.ts
@@ -12,6 +12,7 @@ const clientOptionsDefault: IClientOptionsDemo = {
   prefetchIceCandidates: false,
   forceRelayCandidate: false,
   trickleIce: false,
+  singleInterfaceIce: false,
   keepConnectionAliveOnSocketClose: false,
   useCanaryRtcServer: false,
   mutedMicOnStart: false,

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -83,6 +83,7 @@ const ClientOptions = () => {
       prefetchIceCandidates: false,
       forceRelayCandidate: false,
       trickleIce: false,
+      singleInterfaceIce: false,
       useCanaryRtcServer: false,
       ringbackFile: '/ringback.mp3',
       ringtoneFile: '/ringtone.mp3',
@@ -438,6 +439,30 @@ const ClientOptions = () => {
                   <FormControl>
                     <Switch
                       data-testid="switch-trickle-ice"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="singleInterfaceIce"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between mb-4">
+                  <div>
+                    <FormLabel>Single Interface ICE</FormLabel>
+                    <FormDescription>
+                      Restrict ICE candidates to a single network interface.
+                      Prevents DTLS mismatch on multi-NIC clients.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
                       checked={field.value}
                       onCheckedChange={field.onChange}
                     />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export interface IClientOptionsDemo extends IClientOptions {
   rtcIp?: string;
   rtcPort?: number;
   trickleIce?: boolean;
+  singleInterfaceIce?: boolean;
   useCanaryRtcServer?: boolean;
   keepConnectionAliveOnSocketClose?: boolean;
   stunServers?: string[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,7 +4,7 @@ export interface IClientOptionsDemo extends IClientOptions {
   rtcIp?: string;
   rtcPort?: number;
   trickleIce?: boolean;
-  singleInterfaceIce?: boolean;
+  singleInterfaceIce?: boolean; // TODO: remove when singleInterfaceIce is added to IClientOptions in @telnyx/webrtc
   useCanaryRtcServer?: boolean;
   keepConnectionAliveOnSocketClose?: boolean;
   stunServers?: string[];


### PR DESCRIPTION
Adds UI toggle for the `singleInterfaceIce` SDK option ([webrtc PR #558](https://github.com/team-telnyx/webrtc/pull/558)).

When enabled, restricts trickle ICE candidates to a single network interface, preventing DTLS handshake failures on multi-NIC clients.

**Depends on:** @telnyx/webrtc release containing PR #558.

**Changes:**
- `clientOptions.ts` — added `singleInterfaceIce: false` default
- `ClientOptions.tsx` — added toggle with description, placed after Trickle ICE toggle