### PR TITLE
feat: add data-testid to SDK version dropdown, singleInterfaceIce and forceRelayCandidate switches

### DIFF
--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -463,6 +463,7 @@ const ClientOptions = () => {
                   </div>
                   <FormControl>
                     <Switch
+                      data-testid="switch-single-interface-ice"
                       checked={field.value}
                       onCheckedChange={field.onChange}
                     />
@@ -509,6 +510,7 @@ const ClientOptions = () => {
                   </div>
                   <FormControl>
                     <Switch
+                      data-testid="switch-force-relay-candidate"
                       checked={field.value}
                       onCheckedChange={field.onChange}
                     />

--- a/src/components/SDKVersionDropdown.tsx
+++ b/src/components/SDKVersionDropdown.tsx
@@ -118,7 +118,7 @@ const SDKVersionDropdown = () => {
   };
   return (
     <Select value={version} onValueChange={onVersionChange}>
-      <SelectTrigger className="w-[180px]">
+      <SelectTrigger className="w-[180px]" data-testid="select-sdk-version">
         <SelectValue placeholder="SDK version" />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
Adds `data-testid` attributes for blackbox test automation:

- `select-sdk-version` — SDK version dropdown trigger (enables selecting e.g. `2.25.26-beta.4` at runtime)
- `switch-single-interface-ice` — singleInterfaceIce toggle
- `switch-force-relay-candidate` — forceRelayCandidate toggle

These are needed by `blackbox-testing-webrtc` to programmatically test the dual-NIC DTLS mismatch fix (PR #558) and relay-only ICE scenarios.