### PR TITLE
feat: display source datacenter region beside connection status

### DIFF
--- a/src/atoms/telnyxClient.ts
+++ b/src/atoms/telnyxClient.ts
@@ -26,6 +26,7 @@ const telnyxRTCVersionAtom = atom<TelnyxRTCVersion>({
 });
 
 const connectionStatusAtom = atom<string>('disconnected');
+const sourceAtom = atom<string | null>(null);
 
 // SIP.js Simple User status atoms
 export type WsStatus = 'idle' | 'connecting' | 'connected' | 'disconnected';
@@ -86,6 +87,7 @@ export const useTelnyxClient = () => useAtom(clientAtom);
 export const useTelnyxSdkClient = () => useAtom(telnyxRtcClientAtom);
 export const useSipJsClient = () => useAtom(telnyxSipJsClientAtom);
 export const useConnectionStatus = () => useAtom(connectionStatusAtom);
+export const useSource = () => useAtom(sourceAtom);
 export const useTelnyxSDKVersion = () => useAtom(telnyxRTCVersionAtom);
 
 // SIP.js Simple User status hooks

--- a/src/atoms/telnyxClient.ts
+++ b/src/atoms/telnyxClient.ts
@@ -26,8 +26,8 @@ const telnyxRTCVersionAtom = atom<TelnyxRTCVersion>({
 });
 
 const connectionStatusAtom = atom<string>('disconnected');
-const localDcAtom = atom<string | null>(null);
-const localRegionAtom = atom<string | null>(null);
+const dcAtom = atom<string | null>(null);
+const connectedRegionAtom = atom<string | null>(null);
 
 // SIP.js Simple User status atoms
 export type WsStatus = 'idle' | 'connecting' | 'connected' | 'disconnected';
@@ -88,8 +88,8 @@ export const useTelnyxClient = () => useAtom(clientAtom);
 export const useTelnyxSdkClient = () => useAtom(telnyxRtcClientAtom);
 export const useSipJsClient = () => useAtom(telnyxSipJsClientAtom);
 export const useConnectionStatus = () => useAtom(connectionStatusAtom);
-export const useLocalDc = () => useAtom(localDcAtom);
-export const useLocalRegion = () => useAtom(localRegionAtom);
+export const useDc = () => useAtom(dcAtom);
+export const useConnectedRegion = () => useAtom(connectedRegionAtom);
 export const useTelnyxSDKVersion = () => useAtom(telnyxRTCVersionAtom);
 
 // SIP.js Simple User status hooks

--- a/src/atoms/telnyxClient.ts
+++ b/src/atoms/telnyxClient.ts
@@ -26,7 +26,8 @@ const telnyxRTCVersionAtom = atom<TelnyxRTCVersion>({
 });
 
 const connectionStatusAtom = atom<string>('disconnected');
-const sourceAtom = atom<string | null>(null);
+const localDcAtom = atom<string | null>(null);
+const localRegionAtom = atom<string | null>(null);
 
 // SIP.js Simple User status atoms
 export type WsStatus = 'idle' | 'connecting' | 'connected' | 'disconnected';
@@ -87,7 +88,8 @@ export const useTelnyxClient = () => useAtom(clientAtom);
 export const useTelnyxSdkClient = () => useAtom(telnyxRtcClientAtom);
 export const useSipJsClient = () => useAtom(telnyxSipJsClientAtom);
 export const useConnectionStatus = () => useAtom(connectionStatusAtom);
-export const useSource = () => useAtom(sourceAtom);
+export const useLocalDc = () => useAtom(localDcAtom);
+export const useLocalRegion = () => useAtom(localRegionAtom);
 export const useTelnyxSDKVersion = () => useAtom(telnyxRTCVersionAtom);
 
 // SIP.js Simple User status hooks

--- a/src/components/ClientAutoConnect.tsx
+++ b/src/components/ClientAutoConnect.tsx
@@ -1,6 +1,7 @@
 import {
   useConnectionStatus,
-  useSource,
+  useLocalDc,
+  useLocalRegion,
   useTelnyxSdkClient,
 } from '@/atoms/telnyxClient';
 import { useEffect } from 'react';
@@ -16,7 +17,8 @@ type SocketMessage = {
 const ClientAutoConnect = () => {
   const [client] = useTelnyxSdkClient();
   const [, setStatus] = useConnectionStatus();
-  const [, setSource] = useSource();
+  const [, setLocalDc] = useLocalDc();
+  const [, setLocalRegion] = useLocalRegion();
 
   useEffect(() => {
     if (!client) {
@@ -26,10 +28,16 @@ const ClientAutoConnect = () => {
     const onReady = () => {
       setStatus('registered');
 
-      // @ts-expect-error `source` is added in @telnyx/webrtc PR #583 but not yet in published types
-      const source: string | undefined = client.source;
-      if (source) {
-        setSource(source);
+      // @ts-expect-error `localDc` is added in @telnyx/webrtc PR #583 but not yet in published types
+      const localDc: string | undefined = client.localDc;
+      if (localDc) {
+        setLocalDc(localDc);
+      }
+
+      // @ts-expect-error `localRegion` is added in @telnyx/webrtc PR #583 but not yet in published types
+      const localRegion: string | undefined = client.localRegion;
+      if (localRegion) {
+        setLocalRegion(localRegion);
       }
     };
     const onSocketMessage = (message: SocketMessage) => {
@@ -48,7 +56,8 @@ const ClientAutoConnect = () => {
 
     const onSocketClose = () => {
       setStatus('disconnected');
-      setSource(null);
+      setLocalDc(null);
+      setLocalRegion(null);
     };
     const onSocketError = () => {
       setStatus('disconnected');
@@ -66,7 +75,8 @@ const ClientAutoConnect = () => {
 
     return () => {
       setStatus('disconnected');
-      setSource(null);
+      setLocalDc(null);
+      setLocalRegion(null);
       client.disconnect();
       client.off('telnyx.ready', onReady);
       client.off('telnyx.error', onError);
@@ -75,7 +85,7 @@ const ClientAutoConnect = () => {
       client.off('telnyx.socket.close', onSocketClose);
       client.off('telnyx.socket.error', onSocketError);
     };
-  }, [client, setStatus, setSource]);
+  }, [client, setStatus, setLocalDc, setLocalRegion]);
   return null;
 };
 

--- a/src/components/ClientAutoConnect.tsx
+++ b/src/components/ClientAutoConnect.tsx
@@ -1,4 +1,8 @@
-import { useConnectionStatus, useTelnyxSdkClient } from '@/atoms/telnyxClient';
+import {
+  useConnectionStatus,
+  useSource,
+  useTelnyxSdkClient,
+} from '@/atoms/telnyxClient';
 import { useEffect } from 'react';
 
 type SocketMessage = {
@@ -12,6 +16,7 @@ type SocketMessage = {
 const ClientAutoConnect = () => {
   const [client] = useTelnyxSdkClient();
   const [, setStatus] = useConnectionStatus();
+  const [, setSource] = useSource();
 
   useEffect(() => {
     if (!client) {
@@ -20,6 +25,12 @@ const ClientAutoConnect = () => {
 
     const onReady = () => {
       setStatus('registered');
+
+      // @ts-expect-error `source` is added in @telnyx/webrtc PR #583 but not yet in published types
+      const source: string | undefined = client.source;
+      if (source) {
+        setSource(source);
+      }
     };
     const onSocketMessage = (message: SocketMessage) => {
       if (['REGISTER', 'REGED'].includes(message.result?.params.state)) {
@@ -37,6 +48,7 @@ const ClientAutoConnect = () => {
 
     const onSocketClose = () => {
       setStatus('disconnected');
+      setSource(null);
     };
     const onSocketError = () => {
       setStatus('disconnected');
@@ -54,6 +66,7 @@ const ClientAutoConnect = () => {
 
     return () => {
       setStatus('disconnected');
+      setSource(null);
       client.disconnect();
       client.off('telnyx.ready', onReady);
       client.off('telnyx.error', onError);
@@ -62,7 +75,7 @@ const ClientAutoConnect = () => {
       client.off('telnyx.socket.close', onSocketClose);
       client.off('telnyx.socket.error', onSocketError);
     };
-  }, [client, setStatus]);
+  }, [client, setStatus, setSource]);
   return null;
 };
 

--- a/src/components/ClientAutoConnect.tsx
+++ b/src/components/ClientAutoConnect.tsx
@@ -1,7 +1,7 @@
 import {
   useConnectionStatus,
-  useLocalDc,
-  useLocalRegion,
+  useConnectedRegion,
+  useDc,
   useTelnyxSdkClient,
 } from '@/atoms/telnyxClient';
 import { useEffect } from 'react';
@@ -17,8 +17,8 @@ type SocketMessage = {
 const ClientAutoConnect = () => {
   const [client] = useTelnyxSdkClient();
   const [, setStatus] = useConnectionStatus();
-  const [, setLocalDc] = useLocalDc();
-  const [, setLocalRegion] = useLocalRegion();
+  const [, setDc] = useDc();
+  const [, setConnectedRegion] = useConnectedRegion();
 
   useEffect(() => {
     if (!client) {
@@ -28,16 +28,16 @@ const ClientAutoConnect = () => {
     const onReady = () => {
       setStatus('registered');
 
-      // @ts-expect-error `localDc` is added in @telnyx/webrtc PR #583 but not yet in published types
-      const localDc: string | undefined = client.localDc;
-      if (localDc) {
-        setLocalDc(localDc);
+      // @ts-expect-error `dc` is added in @telnyx/webrtc PR #583 but not yet in published types
+      const dc: string | undefined = client.dc;
+      if (dc) {
+        setDc(dc);
       }
 
-      // @ts-expect-error `localRegion` is added in @telnyx/webrtc PR #583 but not yet in published types
-      const localRegion: string | undefined = client.localRegion;
-      if (localRegion) {
-        setLocalRegion(localRegion);
+      // @ts-expect-error `region` is added in @telnyx/webrtc PR #583 but not yet in published types
+      const region: string | undefined = client.region;
+      if (region) {
+        setConnectedRegion(region);
       }
     };
     const onSocketMessage = (message: SocketMessage) => {
@@ -56,8 +56,8 @@ const ClientAutoConnect = () => {
 
     const onSocketClose = () => {
       setStatus('disconnected');
-      setLocalDc(null);
-      setLocalRegion(null);
+      setDc(null);
+      setConnectedRegion(null);
     };
     const onSocketError = () => {
       setStatus('disconnected');
@@ -75,8 +75,8 @@ const ClientAutoConnect = () => {
 
     return () => {
       setStatus('disconnected');
-      setLocalDc(null);
-      setLocalRegion(null);
+      setDc(null);
+      setConnectedRegion(null);
       client.disconnect();
       client.off('telnyx.ready', onReady);
       client.off('telnyx.error', onError);
@@ -85,7 +85,7 @@ const ClientAutoConnect = () => {
       client.off('telnyx.socket.close', onSocketClose);
       client.off('telnyx.socket.error', onSocketError);
     };
-  }, [client, setStatus, setLocalDc, setLocalRegion]);
+  }, [client, setStatus, setDc, setConnectedRegion]);
   return null;
 };
 

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -1,9 +1,10 @@
 import { useClientOptions } from '@/atoms/clientOptions';
-import { useConnectionStatus } from '@/atoms/telnyxClient';
+import { useConnectionStatus, useSource } from '@/atoms/telnyxClient';
 import { clsx } from 'clsx';
 
 const ConnectionStatus = () => {
   const [status] = useConnectionStatus();
+  const [source] = useSource();
   const [clientOptions] = useClientOptions();
   return (
     <h3
@@ -14,6 +15,7 @@ const ConnectionStatus = () => {
       })}
     >
       {status} ({status === 'registered' && clientOptions.login})
+      {source && <span className='ml-2 text-sm opacity-75'>region: {source}</span>}
     </h3>
   );
 };

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -1,11 +1,11 @@
 import { useClientOptions } from '@/atoms/clientOptions';
-import { useConnectionStatus, useLocalDc, useLocalRegion } from '@/atoms/telnyxClient';
+import { useConnectionStatus, useConnectedRegion, useDc } from '@/atoms/telnyxClient';
 import { clsx } from 'clsx';
 
 const ConnectionStatus = () => {
   const [status] = useConnectionStatus();
-  const [localDc] = useLocalDc();
-  const [localRegion] = useLocalRegion();
+  const [dc] = useDc();
+  const [connectedRegion] = useConnectedRegion();
   const [clientOptions] = useClientOptions();
   return (
     <h3
@@ -16,8 +16,8 @@ const ConnectionStatus = () => {
       })}
     >
       {status} ({status === 'registered' && clientOptions.login})
-      {localRegion && <span className='ml-2 text-sm opacity-75'>region: {localRegion}</span>}
-      {localDc && <span className='ml-2 text-sm opacity-75'>dc: {localDc}</span>}
+      {connectedRegion && <span className='ml-2 text-sm opacity-75'>region: {connectedRegion}</span>}
+      {dc && <span className='ml-2 text-sm opacity-75'>dc: {dc}</span>}
     </h3>
   );
 };

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -1,10 +1,11 @@
 import { useClientOptions } from '@/atoms/clientOptions';
-import { useConnectionStatus, useSource } from '@/atoms/telnyxClient';
+import { useConnectionStatus, useLocalDc, useLocalRegion } from '@/atoms/telnyxClient';
 import { clsx } from 'clsx';
 
 const ConnectionStatus = () => {
   const [status] = useConnectionStatus();
-  const [source] = useSource();
+  const [localDc] = useLocalDc();
+  const [localRegion] = useLocalRegion();
   const [clientOptions] = useClientOptions();
   return (
     <h3
@@ -15,7 +16,8 @@ const ConnectionStatus = () => {
       })}
     >
       {status} ({status === 'registered' && clientOptions.login})
-      {source && <span className='ml-2 text-sm opacity-75'>region: {source}</span>}
+      {localRegion && <span className='ml-2 text-sm opacity-75'>region: {localRegion}</span>}
+      {localDc && <span className='ml-2 text-sm opacity-75'>dc: {localDc}</span>}
     </h3>
   );
 };


### PR DESCRIPTION
## Summary
- Adds `localDcAtom` and `localRegionAtom` to track the datacenter and region from the SDK session
- Reads `client.localDc` and `client.localRegion` on `telnyx.ready` event
- Displays both region and datacenter beside the connection status when registered

## Dependencies
- team-telnyx/webrtc#583 — stores `localDc` and `localRegion` from REGED message on the SDK session

## Test plan
- [ ] Deploy with an SDK build that includes team-telnyx/webrtc#583
- [ ] Connect and verify region (e.g. `region: us-central`) and dc (e.g. `dc: ch1-prod`) appear next to connection status
- [ ] Verify both clear on disconnect
- [ ] Verify nothing extra is shown when fields are not present (older SDK/proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)