### PR TITLE
feat: display widget dc, region and call_report_id in the AI agent tab

### DIFF
--- a/src/components/AiAgentView.tsx
+++ b/src/components/AiAgentView.tsx
@@ -90,6 +90,11 @@ const AiAgentView = () => {
   const [availableVersions, setAvailableVersions] = useState<string[]>([]);
   const [versionsLoading, setVersionsLoading] = useState(true);
   const [events, setEvents] = useState<AiAgentEvent[]>([]);
+  const [widgetConnectionInfo, setWidgetConnectionInfo] = useState<{
+    dc: string | null;
+    region: string | null;
+    callReportId: string | null;
+  } | null>(null);
   const [customAttributes, setCustomAttributes] = useState<CustomAttribute[]>(
     [],
   );
@@ -128,6 +133,28 @@ const AiAgentView = () => {
         timestamp: new Date(),
       };
       setEvents((prev) => [newEvent, ...prev]);
+
+      // Capture widget-side connection metadata from `agent.connected`.
+      // The widget emits `{ dc, region, callReportId }` in the event detail
+      // (see telnyx-voice-ai-widget#NN). On SDK versions that pre-date
+      // team-telnyx/webrtc#583 the dc/region fields will be null; the
+      // callReportId works with any version that ships BaseSession.callReportId.
+      if (event.data.eventType === 'agent.connected') {
+        const detail = event.data.detail as
+          | {
+              dc?: string | null;
+              region?: string | null;
+              callReportId?: string | null;
+            }
+          | undefined;
+        setWidgetConnectionInfo({
+          dc: detail?.dc ?? null,
+          region: detail?.region ?? null,
+          callReportId: detail?.callReportId ?? null,
+        });
+      } else if (event.data.eventType === 'agent.disconnected') {
+        setWidgetConnectionInfo(null);
+      }
     }
   }, []);
 
@@ -300,6 +327,7 @@ const AiAgentView = () => {
     setCurrentFormValues(null);
     setCurrentCustomAttrs([]);
     setEvents([]);
+    setWidgetConnectionInfo(null);
     setCustomAttributes([]);
     form.reset();
   };
@@ -771,13 +799,41 @@ const AiAgentView = () => {
 
       <Card className="flex flex-col min-h-[600px]">
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <div>
+          <div className="flex-1 min-w-0">
             <CardTitle>Widget Preview</CardTitle>
             <CardDescription>
               {isEmbedded && currentFormValues
                 ? `Showing agent: ${currentFormValues.agentId}`
                 : 'Enter an Agent ID and click Embed to see the widget.'}
             </CardDescription>
+            {widgetConnectionInfo &&
+              (widgetConnectionInfo.region ||
+                widgetConnectionInfo.dc ||
+                widgetConnectionInfo.callReportId) && (
+                <div
+                  className="mt-1 text-xs text-muted-foreground space-x-2 truncate"
+                  data-testid="widget-connection-info"
+                >
+                  {widgetConnectionInfo.region && (
+                    <span data-testid="widget-connection-info-region">
+                      region: {widgetConnectionInfo.region}
+                    </span>
+                  )}
+                  {widgetConnectionInfo.dc && (
+                    <span data-testid="widget-connection-info-dc">
+                      dc: {widgetConnectionInfo.dc}
+                    </span>
+                  )}
+                  {widgetConnectionInfo.callReportId && (
+                    <span
+                      className="font-mono"
+                      data-testid="widget-connection-info-call-report-id"
+                    >
+                      call_report_id: {widgetConnectionInfo.callReportId}
+                    </span>
+                  )}
+                </div>
+              )}
           </div>
           <Button
             type="button"


### PR DESCRIPTION
## Summary

Display the widget-side `{ dc, region, callReportId }` from the AI agent widget's `agent.connected` event in the **Widget Preview** card header on the AI Agent tab.

This mirrors what the main TelnyxRTC tab already does (#82) — it shows the same info next to the connection status — but sourced from the widget's event stream instead of direct SDK client access, because the widget runs inside an iframe.

## Changes

In `src/components/AiAgentView.tsx`:

- New `widgetConnectionInfo` state: `{ dc, region, callReportId } | null`.
- Existing `handleWidgetEvent` (which already forwards iframe `postMessage` to the event log) now also extracts the `agent.connected` detail and populates `widgetConnectionInfo`. Cleared on `agent.disconnected` and on the Reset button.
- New render block inside the **Widget Preview** card header `<CardDescription>`, just below the "Showing agent: …" line. Subtle `text-xs text-muted-foreground`, with per-field `data-testid` hooks:
  - `widget-connection-info`
  - `widget-connection-info-region`
  - `widget-connection-info-dc`
  - `widget-connection-info-call-report-id`

### Why `call_report_id` IS rendered here (but not in the widget itself)

In the widget, `call_report_id` is intentionally only emitted via the `agent.connected` event (to keep the UI clean and mirror how latency info is emitted via `conversation.agent.state`). This demo tab is a debug playground, so it's the right place to actually *display* the id — that's the point of having the event API in the first place.

## Dependency chain

- `callReportId` works immediately against the current published `@telnyx/ai-agent-widget` once the [companion widget PR](https://github.com/team-telnyx/telnyx-voice-ai-widget/pull/38) is released as a beta. It is available from `BaseSession.callReportId` on every shipped `@telnyx/webrtc` version.
- `dc` and `region` require team-telnyx/webrtc#583 to merge → webrtc release → @telnyx/ai-agent-lib release → @telnyx/ai-agent-widget release. Until that chain clears, the fields will be `null` in the widget's event payload and the render block here will simply skip them. The render condition is `if (region || dc || callReportId)` so the block stays invisible until something is populated.

## Screenshot

(to be added after end-to-end test against the beta widget release)
