### PR TITLE
feat: add skip-last-voice-sdk-id toggle to AI Agent demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.26.1",
+    "@telnyx/webrtc": "2.26.4",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/components/AiAgentView.tsx
+++ b/src/components/AiAgentView.tsx
@@ -58,6 +58,7 @@ interface FormValues {
   debug: boolean;
   showUserPerceivedLatency: boolean;
   showGreetingLatency: boolean;
+  skipLastVoiceSdkId: boolean;
   // Call options
   callDestinationNumber: string;
   callCallerNumber: string;
@@ -106,6 +107,7 @@ const AiAgentView = () => {
       debug: false,
       showUserPerceivedLatency: false,
       showGreetingLatency: false,
+      skipLastVoiceSdkId: true,
       callDestinationNumber: '',
       callCallerNumber: '',
       callCallerName: '',
@@ -205,6 +207,9 @@ const AiAgentView = () => {
       attrs.push('show-user-perceived-latency="true"');
     if (values.showGreetingLatency)
       attrs.push('show-greeting-latency="true"');
+    // skip-last-voice-sdk-id defaults to true in the widget, but we
+    // explicitly emit it when the user opts out so the demo is transparent.
+    if (!values.skipLastVoiceSdkId) attrs.push('skip-last-voice-sdk-id="false"');
 
     // Region (skip if auto — let the SDK use default)
     if (values.region && values.region !== 'auto')
@@ -569,6 +574,27 @@ const AiAgentView = () => {
                         <FormControl>
                           <Switch
                             data-testid="switch-show-greeting-latency"
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="skipLastVoiceSdkId"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
+                        <div className="space-y-0.5">
+                          <FormLabel>Skip Last Voice SDK ID</FormLabel>
+                          <p className="text-sm text-muted-foreground">
+                            On reconnect, route to a fresh b2bua-rtc instance
+                          </p>
+                        </div>
+                        <FormControl>
+                          <Switch
+                            data-testid="switch-skip-last-voice-sdk-id"
                             checked={field.value}
                             onCheckedChange={field.onChange}
                           />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.26.1":
-  version "2.26.1"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.26.1.tgz#2061c3c50095654c080a1a2617e75ad98e5d36f5"
-  integrity sha512-DrZyV6WchlMgR+YZ2vl0Dwnlb6K4dvwlA7r6kiI7Ya+rIrwTQxmLQnjlAWYkLoYnX9n7AZj66Zj85QJCbNbbtA==
+"@telnyx/webrtc@2.26.4":
+  version "2.26.4"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.26.4.tgz#93cff05a2f0a5e45cff2b0627010aedc188b1165"
+  integrity sha512-VRccuBiENAZiHB48Jc88MMdV6WKAfw/5wzXUMvYjpNB70/aMaf2rMEbsjojJ2ZUHTSUpR04KMU5M8xenWl0hgw==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
- Defaults to enabled (true) to match widget behavior\n- When disabled, emits skip-last-voice-sdk-id=false attribute\n\nDepends on telnyx-voice-ai-widget v0.33.2+