### PR TITLE
chore: bump webrtc to 2.27.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.26.4",
+    "@telnyx/webrtc": "2.27.0-beta.1",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.26.4":
-  version "2.26.4"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.26.4.tgz#93cff05a2f0a5e45cff2b0627010aedc188b1165"
-  integrity sha512-VRccuBiENAZiHB48Jc88MMdV6WKAfw/5wzXUMvYjpNB70/aMaf2rMEbsjojJ2ZUHTSUpR04KMU5M8xenWl0hgw==
+"@telnyx/webrtc@2.27.0-beta.1":
+  version "2.27.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.0-beta.1.tgz#7e4fc4085da4a740bb775047db25e2f10ab12f56"
+  integrity sha512-xlO/phIoFE4goEDoYqHBjuI4+P2315mp7/Ekd4YkXtS03gLtOqUkdCPuy0ubC0r3EOT5iASjps2IgUnCdKRfrQ==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary
- bump `@telnyx/webrtc` demo app dependency to `2.27.0-beta.1`
- update `yarn.lock` to resolve the beta tarball

## Verification
- ✅ `yarn build:development`
- ⚠️ `yarn lint` currently fails on existing lint errors unrelated to this dependency bump (React hooks/no-unused-vars in existing files)