### PR TITLE
chore: update WebRTC SDK beta to 2.27.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.0-beta.3",
+    "@telnyx/webrtc": "2.27.0-beta.5",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.0-beta.3":
-  version "2.27.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.0-beta.3.tgz#762c72a30df271fd976d48a79086db39774c78a3"
-  integrity sha512-L3qTvLpHSXYOIAjz4NFzIIJQiKDoK7a2PXloz7MIj2shEKkbYvgd0fJSktG782kaaFevQXGllYm/3OiR7HRBzA==
+"@telnyx/webrtc@2.27.0-beta.5":
+  version "2.27.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.0-beta.5.tgz#109825af8960b5403d59691acf31a6e8e40b9f10"
+  integrity sha512-/Bf9amoRSmrUKKimun4DoW5WwZExUKxOXeR3ixeZojWfNbJiXMBtZ2OlVqdpc2vmNub34WDidLPt7tNBZjNJTQ==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary
- Updates `@telnyx/webrtc` from `2.27.0-beta.3` to `2.27.0-beta.5`
- Refreshes `yarn.lock`

## Validation
- `yarn install --mode update-lockfile`
- `yarn build:production`