### PR TITLE
feat: allow socket disconnect during active call

### DIFF
--- a/src/components/ActiveCall.tsx
+++ b/src/components/ActiveCall.tsx
@@ -25,6 +25,7 @@ import {
   SelectValue,
 } from './ui/select';
 import { useDevices } from '@/hooks/useDevices';
+import { useConnectionStatus, useTelnyxSdkClient } from '@/atoms/telnyxClient';
 import VideoPlayer from './VideoPlayer';
 
 type Props = {
@@ -34,6 +35,8 @@ type Props = {
 
 const ActiveCall = ({ call, title = 'Active Call' }: Props) => {
   const devices = useDevices();
+  const [client] = useTelnyxSdkClient();
+  const [connectionStatus, setConnectionStatus] = useConnectionStatus();
   const [isMuted, setIsMuted] = useState<boolean>(call.isAudioMuted);
   const [selectedAudioInputId, setSelectedAudioInputId] = useState<string>('');
   const [newAudioInDeviceMuted, setNewAudioInDeviceMuted] = useState(
@@ -59,6 +62,13 @@ const ActiveCall = ({ call, title = 'Active Call' }: Props) => {
     } catch (error) {
       console.error('Failed to switch audio input', error);
     }
+  };
+
+  const disconnectSocket = () => {
+    if (client) {
+      client.disconnect();
+    }
+    setConnectionStatus('disconnected');
   };
 
   useEffect(() => {
@@ -213,6 +223,17 @@ const ActiveCall = ({ call, title = 'Active Call' }: Props) => {
             onClick={() => call.hold()}
           >
             Hold
+          </Button>
+
+          <Button
+            data-testid="btn-disconnect-socket"
+            size="lg"
+            variant={'outline'}
+            className="w-full"
+            disabled={connectionStatus === 'disconnected'}
+            onClick={disconnectSocket}
+          >
+            Disconnect Socket
           </Button>
 
           <Button


### PR DESCRIPTION
## Summary
- add a `Disconnect Socket` button to the active call dialog
- call `client.disconnect()` without hanging up the active call
- update connection status to `disconnected` after the manual socket disconnect

## Testing
- `yarn install --frozen-lockfile`
- `yarn build:development`
- `git diff --check`

## Notes
- `yarn lint` is currently blocked by pre-existing lint errors on `main` (set-state-in-effect and one unused variable in unrelated files).
