### PR TITLE
chore: update WebRTC SDK beta to 2.27.0-beta.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.0-beta.5",
+    "@telnyx/webrtc": "2.27.0-beta.6",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.0-beta.5":
-  version "2.27.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.0-beta.5.tgz#109825af8960b5403d59691acf31a6e8e40b9f10"
-  integrity sha512-/Bf9amoRSmrUKKimun4DoW5WwZExUKxOXeR3ixeZojWfNbJiXMBtZ2OlVqdpc2vmNub34WDidLPt7tNBZjNJTQ==
+"@telnyx/webrtc@2.27.0-beta.6":
+  version "2.27.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.0-beta.6.tgz#83cf313927312b83d17c8b6c859e28aedfed4f6f"
+  integrity sha512-is0FQdshW+Erf0jMzHIwJc+t6OQRUD0145D2IOxOPlEnZC0A+1A5VC/1lxcyE7G09u7VCDQFfp14kgWaLYn8EQ==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary
- Update @telnyx/webrtc from 2.27.0-beta.5 to 2.27.0-beta.6.
- Refresh yarn.lock to use the published beta.6 tarball.

## Verification
- npm view @telnyx/webrtc@2.27.0-beta.6 version dist.tarball --json
- yarn build:production ✅
- yarn lint ⚠️ fails on existing lint issues unrelated to this version bump (set-state-in-effect/no-unused-vars in existing source files).