### PR TITLE
chore: update WebRTC SDK to 2.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.0-beta.5",
+    "@telnyx/webrtc": "2.27.0",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.0-beta.5":
-  version "2.27.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.0-beta.5.tgz#109825af8960b5403d59691acf31a6e8e40b9f10"
-  integrity sha512-/Bf9amoRSmrUKKimun4DoW5WwZExUKxOXeR3ixeZojWfNbJiXMBtZ2OlVqdpc2vmNub34WDidLPt7tNBZjNJTQ==
+"@telnyx/webrtc@2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.0.tgz#91703236a6776cf019400f563957dbda6264902d"
+  integrity sha512-Pe6+oEd9apDFSMJx84TQEnQlDjnBv8yKc5zHVLwNS4KawANXe3Vp/FGVNh2dRQe1Vw6xLg334JSvs9hWk3XB6g==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary
- Update `@telnyx/webrtc` from `2.27.0-beta.5` to stable `2.27.0`
- Refresh `yarn.lock` for the published stable SDK package

## Verification
- [x] Confirmed `@telnyx/webrtc@2.27.0` is published on npm
- [x] `git diff --check`
- [x] `yarn build:production`

## Notes
- Version-only demo app dependency update.
- Build passes with existing Vite/Browserslist warnings unrelated to this dependency bump.