### PR TITLE
feat: add beforeunload hangup option

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.0",
+    "@telnyx/webrtc": "2.27.1-beta.0",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/atoms/clientOptions.ts
+++ b/src/atoms/clientOptions.ts
@@ -14,6 +14,7 @@ const clientOptionsDefault: IClientOptionsDemo = {
   trickleIce: false,
   singleInterfaceIce: false,
   keepConnectionAliveOnSocketClose: false,
+  hangupOnBeforeUnload: true,
   useCanaryRtcServer: false,
   mutedMicOnStart: false,
   enableCallReports: true,

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -84,6 +84,7 @@ const ClientOptions = () => {
       forceRelayCandidate: false,
       trickleIce: false,
       singleInterfaceIce: false,
+      hangupOnBeforeUnload: true,
       useCanaryRtcServer: false,
       ringbackFile: '/ringback.mp3',
       ringtoneFile: '/ringtone.mp3',
@@ -536,6 +537,32 @@ const ClientOptions = () => {
                   <FormControl>
                     <Switch
                       checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="hangupOnBeforeUnload"
+              render={({ field }) => (
+                <FormItem className="flex items-center mb-4 justify-between">
+                  <div>
+                    <FormLabel>Hang up on Before Unload</FormLabel>
+                    <FormDescription>
+                      Send a best-effort BYE when the page refreshes, closes, or
+                      navigates away. Disable this when testing app-managed page
+                      lifecycle handling.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      data-testid="switch-hangup-on-before-unload"
+                      checked={field.value ?? true}
                       onCheckedChange={field.onChange}
                     />
                   </FormControl>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,7 @@ export interface IClientOptionsDemo extends IClientOptions {
   singleInterfaceIce?: boolean; // TODO: remove when singleInterfaceIce is added to IClientOptions in @telnyx/webrtc
   useCanaryRtcServer?: boolean;
   keepConnectionAliveOnSocketClose?: boolean;
+  hangupOnBeforeUnload?: boolean;
   stunServers?: string[];
   turnServers?: TurnServer;
   video?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.0.tgz#91703236a6776cf019400f563957dbda6264902d"
-  integrity sha512-Pe6+oEd9apDFSMJx84TQEnQlDjnBv8yKc5zHVLwNS4KawANXe3Vp/FGVNh2dRQe1Vw6xLg334JSvs9hWk3XB6g==
+"@telnyx/webrtc@2.27.1-beta.0":
+  version "2.27.1-beta.0"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.1-beta.0.tgz#94d6a9f3e52ea467b4914866111314a73222d6e2"
+  integrity sha512-PA+16134YhsYeaMlFWQWhMc/N9mtkBJLBbAeVT5nmye1LzOjo2Sy7XVik3ePp3MzUDb3u2713A383ScmnkOTnA==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary
- update `@telnyx/webrtc` to `2.27.1-beta.0`
- add a Client Options toggle for `hangupOnBeforeUnload`
- default the toggle to current SDK behavior (`true`) so existing demo profiles stay backwards-compatible

## Why
`hangupOnBeforeUnload` was added in team-telnyx/webrtc#653 so apps can opt out of the SDK beforeunload BYE handler when page lifecycle is managed elsewhere.

## Test plan
- ✅ `yarn build:development`
- ⚠️ `yarn lint` currently fails on existing repo lint errors outside these changes (`ActiveCall.tsx`, `AiAgentView.tsx`, `AudioVisualizer.tsx`, `SipJsActiveCall.tsx`, `useDevices.ts`)

## Related
- team-telnyx/webrtc#653
- team-telnyx/webrtc#654
- https://github.com/team-telnyx/webrtc/releases/tag/webrtc/v2.27.1-beta.0
