### PR TITLE
chore: update webrtc sdk to 2.27.1-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.1-beta.0",
+    "@telnyx/webrtc": "2.27.1-beta.2",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.1-beta.0":
-  version "2.27.1-beta.0"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.1-beta.0.tgz#94d6a9f3e52ea467b4914866111314a73222d6e2"
-  integrity sha512-PA+16134YhsYeaMlFWQWhMc/N9mtkBJLBbAeVT5nmye1LzOjo2Sy7XVik3ePp3MzUDb3u2713A383ScmnkOTnA==
+"@telnyx/webrtc@2.27.1-beta.2":
+  version "2.27.1-beta.2"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.1-beta.2.tgz#f3795563dcc5f6e188e5ea24a979cd522c9cad85"
+  integrity sha512-SA/jSgWonnFwjGnDIGVbGBXx6oCjpiyA2+jlUmMJAS+LquOYmfI1S8oEzNxxYvZ5orWeL+qCyIsNhJkoDV2vpQ==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary
- update `@telnyx/webrtc` from `2.27.1-beta.0` to `2.27.1-beta.2`

## Validation
- `yarn build:production`

## Notes
- `yarn lint` currently fails on existing React lint issues unrelated to this dependency bump (`react-hooks/set-state-in-effect`, `react-refresh/only-export-components`, etc.).
