### PR TITLE
chore: update WebRTC SDK to 2.27.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.1-beta.4",
+    "@telnyx/webrtc": "2.27.1",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.1-beta.4":
-  version "2.27.1-beta.4"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.1-beta.4.tgz#17e75406dc1c18fb3047221da89fca378913a6ee"
-  integrity sha512-9uAE8A9Pxsfesu/eHf7MTNWTU1LbEnHb4bG3S4SBGrbHFnDUs/ApOgVb/zMz5zSrR7vR4LGRfC2cdxvjnoSsmg==
+"@telnyx/webrtc@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.1.tgz#2ee16fc40ca9edb6ac4783a5829d7e26349537a6"
+  integrity sha512-fjsMTX/srcskv2O5s2tqXVzRHu8QuBDiF8igtpKi9E2yxD+A5hjD/42GjIfUTl65kIW50K2ZL3eI6Za6Sq2+Fw==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary
- update `@telnyx/webrtc` from `2.27.1-beta.4` to stable `2.27.1`
- refresh `yarn.lock`

## Verification
- [x] `yarn build:production`
- [ ] `yarn lint` (fails on existing unrelated lint issues in untouched files)