### PR TITLE
VSDK-213: add skipTrailing switch to ClientOptions

### DIFF
--- a/src/atoms/clientOptions.ts
+++ b/src/atoms/clientOptions.ts
@@ -16,6 +16,7 @@ const clientOptionsDefault: IClientOptionsDemo = {
   keepConnectionAliveOnSocketClose: false,
   hangupOnBeforeUnload: true,
   useCanaryRtcServer: false,
+  skipTrailing: false,
   mutedMicOnStart: false,
   enableCallReports: true,
   mediaPermissionsRecovery: {

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -86,6 +86,7 @@ const ClientOptions = () => {
       singleInterfaceIce: false,
       hangupOnBeforeUnload: true,
       useCanaryRtcServer: false,
+      skipTrailing: false,
       ringbackFile: '/ringback.mp3',
       ringtoneFile: '/ringtone.mp3',
       rtcIp: '',
@@ -587,6 +588,32 @@ const ClientOptions = () => {
                   <FormControl>
                     <Switch
                       data-testid="switch-canary-rtc-server"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="skipTrailing"
+              render={({ field }) => (
+                <FormItem className="flex items-center mb-4 justify-between">
+                  <div>
+                    <FormLabel>Skip Trailing</FormLabel>
+                    <FormDescription>
+                      Skip VSP pre-routing identity resolution (trailing
+                      release routing). Intended for internal/test-infra
+                      usage only.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      data-testid="switch-skip-trailing"
                       checked={field.value}
                       onCheckedChange={field.onChange}
                     />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,7 @@ export interface IClientOptionsDemo extends IClientOptions {
   stunServers?: string[];
   turnServers?: TurnServer;
   video?: boolean;
+  skipTrailing?: boolean;
 }
 
 export type TurnServer = {


### PR DESCRIPTION
## Summary

Implements demo-app-side changes for VSDK-213: adds a `skipTrailing` UI switch to the ClientOptions component so BBT and other internal tools can enable the option through the webdialer interface.

## Changes

- Added `skipTrailing?: boolean` to `IClientOptionsDemo`
- Added default value in `clientOptionsAtom`
- Added UI switch with `data-testid="switch-skip-trailing"` for BBT automation

## Related PRs

- team-telnyx/webrtc#669 (SDK changes)
- team-telnyx/blackbox-testing-webrtc#138 (BBT changes)
- team-telnyx/voice-sdk-proxy#VSDK-213 (VSP server changes)