### PR TITLE
test: intentionally break answer BBT selector

### DIFF
--- a/src/components/IncomingCall.tsx
+++ b/src/components/IncomingCall.tsx
@@ -25,7 +25,7 @@ const IncomingCall = ({ call }: Props) => {
           </p>
         </div>
         <Button
-          data-testid="btn-answer-call"
+          data-testid="btn-answer-call-broken"
           onClick={() => call.answer(callOptions)}
         >
           Answer


### PR DESCRIPTION
## Summary
- Intentionally renames the demo-app inbound answer button test id from `btn-answer-call` to `btn-answer-call-broken`.
- This is a focused BBT breakage probe for answer-call flows only.

## Expected BBT impact
BBT answer flow uses `page.getByTestId('btn-answer-call')` in `src/utils/webdialer.ts`, so the answer button lookup should time out before click.

Expected affected cloudprober/BBT endpoints:
- `/answer/desktop/chrome`
- `/answer/desktop/chrome?trickleIce=true`
- `/answer/mobile/chrome`
- `/answer/mobile/chrome?trickleIce=true`
- `/answer/mobile/firefox`
- `/answer/mobile/firefox?trickleIce=true`
- `/answer/desktop/firefox`
- `/answer/desktop/firefox?trickleIce=true`

These 8 endpoints are present in both `cloudprober-prod.cfg.tpl` and `cloudprober-dev.cfg.tpl` in `tester-cloudprober`.

## Verification
- `yarn prettier --write src/components/IncomingCall.tsx`
- `yarn build:development`
- `yarn eslint src/components/IncomingCall.tsx`
- `git diff --check`

Note: build emits existing non-fatal Vite/Browserslist/chunk-size warnings.
