### PR TITLE
fix: restore answer call test id

### DIFF
--- a/src/components/IncomingCall.tsx
+++ b/src/components/IncomingCall.tsx
@@ -25,7 +25,7 @@ const IncomingCall = ({ call }: Props) => {
           </p>
         </div>
         <Button
-          data-testid="btn-answer-call-broken"
+          data-testid="btn-answer-call"
           onClick={() => call.answer(callOptions)}
         >
           Answer


### PR DESCRIPTION
## Summary
- Restores the inbound answer button `data-testid` back to `btn-answer-call`.
- Reverts the intentional demo-app selector break introduced for answer-call BBT validation.

## Expected impact
- Restores the existing BBT/Playwright selector contract for answer-call probes.
- No BBT code change is needed.

## Verification
- `yarn prettier --write src/components/IncomingCall.tsx`
- `yarn build:development`
- `yarn eslint src/components/IncomingCall.tsx`
- `git diff --check`
