### PR TITLE
chore: tidy black box log controls

### DIFF
--- a/src/atoms/log.ts
+++ b/src/atoms/log.ts
@@ -5,14 +5,23 @@ type LogItemType = {
   description: string;
 };
 
-const logAtom = atom<LogItemType[]>([]);
+type StoredLogItemType = LogItemType & {
+  key: string;
+};
+
+let logSequence = 0;
+
+const logAtom = atom<StoredLogItemType[]>([]);
 
 export const useLog = () => {
   const [logs, setLogs] = useAtom(logAtom);
 
   const pushLog = useCallback(
     (item: LogItemType) => {
-      setLogs((prev) => [item, ...prev]);
+      setLogs((prev) => [
+        { ...item, key: `${item.id}-${logSequence++}` },
+        ...prev,
+      ]);
     },
     [setLogs],
   );

--- a/src/components/BlackBoxTestLog.tsx
+++ b/src/components/BlackBoxTestLog.tsx
@@ -44,18 +44,21 @@ const BlackBoxTestLog = () => {
       </CardHeader>
       <CardContent className="flex-1">
         <pre data-testid="log-webrtc" className="font-mono">
-          {logs.map((log, index) => (
-            <div
-              data-testid={`log-webrtc-children-${log.id}`}
-              key={`${log.id}_${index}`}
-            >
+          {logs.map((log) => (
+            <div data-testid={`log-webrtc-children-${log.id}`} key={log.key}>
               {log.description}
             </div>
           ))}
         </pre>
       </CardContent>
       <CardFooter>
-        <Button variant="outline" className="w-full" onClick={clear}>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full"
+          onClick={clear}
+          data-testid="btn-clear-logs"
+        >
           Clear Logs
         </Button>
       </CardFooter>


### PR DESCRIPTION
## Summary
- add a stable internal key for black box log rows instead of using the array index
- mark the clear logs control as an explicit button and expose a test id for automation

## Test Plan
- yarn prettier --write src/atoms/log.ts src/components/BlackBoxTestLog.tsx
- yarn eslint src/atoms/log.ts src/components/BlackBoxTestLog.tsx
- yarn build:development
- git diff --check

Notes: build still emits existing Browserslist age, dynamic import, and chunk-size warnings.