### PR TITLE
Revert broken answer button test id

### DIFF
--- a/src/components/IncomingCall.tsx
+++ b/src/components/IncomingCall.tsx
@@ -25,7 +25,7 @@ const IncomingCall = ({ call }: Props) => {
           </p>
         </div>
         <Button
-          data-testid="btn-answer-call-broken"
+          data-testid="btn-answer-call"
           onClick={() => call.answer(callOptions)}
         >
           Answer


### PR DESCRIPTION
## Summary
- Reverts 8cbc75be1e56986a99ed37266895eac94b227f42 (`test: break answer call test id`)
- Restores the demo app inbound answer button `data-testid` expected by BBT/deploy checks

## Verification
- `git diff --check origin/main..HEAD`

Emergency revert to unblock deploy.