### PR TITLE
chore: update WebRTC SDK to 2.27.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.2-beta.1",
+    "@telnyx/webrtc": "2.27.2",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.2-beta.1":
-  version "2.27.2-beta.1"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.2-beta.1.tgz#4602feb22ab665f49297c4a2366e4897a4b8cee3"
-  integrity sha512-XZXgeA17aOSxdbqe6B8ChRpckwCxx/Ks9PbTQ57Oj6on+2hNVKBycUR4S4ETOyM8gNPfxwB+mHkFyQzCK2GOtQ==
+"@telnyx/webrtc@2.27.2":
+  version "2.27.2"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.2.tgz#33f51e7b0ebc7775b633f6e24737ba5ccd194fc5"
+  integrity sha512-mHkUAjRQYLdY3d4Mp9WulSegVVoW+iEmyeCW1/NjdACQo4yCpRZAIvEGggO3msgVn1aUPfkkZ0UCpyePA5pjyw==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary
- Bumps `@telnyx/webrtc` from `2.27.2-beta.1` to the stable **2.27.2** release.

## Changed files
- `package.json` — `@telnyx/webrtc` version pin
- `yarn.lock` — lockfile resolution

## Verification
- [x] `npm view @telnyx/webrtc@2.27.2` confirms the stable package is published
- [x] `yarn add @telnyx/webrtc@2.27.2` resolves cleanly (Yarn v1)
- [x] `git diff --check` clean (only `package.json` + `yarn.lock` touched)
- [x] `yarn build:production` succeeds (pre-existing unrelated warnings: stale browserslist DB, dynamic-import-vars in `SDKVersionDropdown.tsx`, chunk-size advisory — not introduced by this bump)

## Notes
- Version-only bump; no source changes. Existing repo-wide lint warnings are unrelated and left untouched per scope.