### PR TITLE
chore: bump @telnyx/webrtc to 2.27.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.2-beta.1",
+    "@telnyx/webrtc": "2.27.3",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.2-beta.1":
-  version "2.27.2-beta.1"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.2-beta.1.tgz#4602feb22ab665f49297c4a2366e4897a4b8cee3"
-  integrity sha512-XZXgeA17aOSxdbqe6B8ChRpckwCxx/Ks9PbTQ57Oj6on+2hNVKBycUR4S4ETOyM8gNPfxwB+mHkFyQzCK2GOtQ==
+"@telnyx/webrtc@2.27.3":
+  version "2.27.3"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.3.tgz#2b58a6940a5e3b63c5d8775d9dfd2893ae3493fe"
+  integrity sha512-fyBbKuaWpRQhLbvZMRk3HVA7bdV6o5UbAniPqAqPZtZqc8zKbyLKQrwkgmIHs7g1bM+k83i9ye15uIHIFfytCw==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
Bumps the bundled Telnyx WebRTC SDK from **2.27.2-beta.1** → **2.27.3** (current npm `latest`, stable).

- `package.json`: `@telnyx/webrtc` `2.27.2-beta.1` → `2.27.3`
- `yarn.lock`: regenerated the `@telnyx/webrtc` entry (resolved/integrity); no transitive dependency changes (`@peermetrics/webrtc-stats ^5.7.1`, `loglevel ^1.6.8` unchanged).

The runtime SDK-version dropdown (esm.sh) is unaffected — this only changes the default bundled version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)