### PR TITLE
demo: default AI widget demo to beta widget

### DIFF
--- a/src/components/AiAgentView.tsx
+++ b/src/components/AiAgentView.tsx
@@ -343,7 +343,7 @@ const AiAgentView = () => {
   const form = useForm<FormValues>({
     defaultValues: {
       agentId: '',
-      version: 'next',
+      version: 'beta',
       versionId: '',
       conversationId: '',
       region: 'auto',
@@ -1201,8 +1201,9 @@ const AiAgentView = () => {
                             Embeds the widget directly (not in an iframe) and
                             registers a <code className="text-xs">send_message</code>{' '}
                             client-side tool that sends an SMS via the Telnyx
-                            Messaging API. Select a beta-marked widget version
-                            (🧪) to enable this feature.
+                            Messaging API. The demo defaults to the widget beta
+                            dist-tag so this exercises the latest client-side
+                            tool API.
                           </p>
                           {!clientToolsAvailableForSelectedVersion && (
                             <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary\n- default the AI Agent Widget version selector to the `beta` dist-tag\n- update client-side tools copy to explain the demo exercises the latest widget beta API\n\n## Verification\n- `yarn build:development`\n- `yarn build:production`\n\nNote: `yarn lint` currently fails on pre-existing baseline React lint errors outside this change; the repo PR workflow runs build only.