### PR TITLE
feat: add ICE server merge mode to demo UI

### DIFF
--- a/src/atoms/clientOptions.ts
+++ b/src/atoms/clientOptions.ts
@@ -13,6 +13,7 @@ const clientOptionsDefault: IClientOptionsDemo = {
   forceRelayCandidate: false,
   trickleIce: false,
   singleInterfaceIce: false,
+  iceServersMode: 'merge',
   keepConnectionAliveOnSocketClose: false,
   hangupOnBeforeUnload: true,
   useCanaryRtcServer: false,

--- a/src/atoms/telnyxClient.ts
+++ b/src/atoms/telnyxClient.ts
@@ -114,7 +114,8 @@ function createTelnyxRTCClient(
     host,
     region: region !== 'auto' ? region : undefined,
 
-    // We can not set iceServers explicitly here, because WebRTC SDK use Telnyx STUN/TURN servers internally based on environment
+    // When iceServers is undefined, the SDK applies its environment-specific defaults.
+    // ClientOptions can also pass a UI-computed merge of defaults + custom servers.
     env: IS_DEV_ENV ? 'development' : 'production',
   });
 }

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -59,6 +59,37 @@ const formatIceServerCredentials = (server: RTCIceServer) => {
   return ` (${server.username || 'no username'} / ${server.credential ? 'credential set' : 'no credential'})`;
 };
 
+const getIceServerKey = (server: RTCIceServer) =>
+  `${formatIceServerUrls(server)}-${server.username ?? ''}-${String(server.credential ?? '')}`;
+
+const IceServerList = ({
+  title,
+  servers,
+  emptyMessage,
+}: {
+  title: string;
+  servers: RTCIceServer[];
+  emptyMessage?: string;
+}) => (
+  <div>
+    <div className="mb-1 font-medium">{title}</div>
+    {servers.length === 0 ? (
+      <div className="text-muted-foreground">
+        {emptyMessage ?? 'No ICE servers configured'}
+      </div>
+    ) : (
+      <ol className="list-decimal space-y-1 pl-5">
+        {servers.map((server) => (
+          <li key={getIceServerKey(server)}>
+            <span className="font-mono">{formatIceServerUrls(server)}</span>
+            {formatIceServerCredentials(server)}
+          </li>
+        ))}
+      </ol>
+    )}
+  </div>
+);
+
 const ClientOptions = () => {
   const [profiles, setProfiles] = useClientProfiles();
   const [clientOptions, setClientOptions] = useClientOptions();
@@ -488,37 +519,30 @@ const ClientOptions = () => {
               )}
             />
             <div className="mb-4 rounded-md border p-3 text-sm">
-              <div className="mb-2 font-medium">Effective ICE servers</div>
-              <div className="mb-2 text-muted-foreground">
-                SDK defaults ({IS_DEV_ENV ? 'development' : 'production'}):{' '}
-                {defaultIceServers.length}. Custom added:{' '}
-                {customIceServers.length}. Effective:{' '}
-                {displayedIceServers.length}.
+              <div className="mb-2 font-medium">ICE server preview</div>
+              <div className="mb-3 text-muted-foreground">
+                Defaults are the SDK {IS_DEV_ENV ? 'development' : 'production'}
+                {' '}ICE servers. Choose merge to append custom entries to the
+                defaults, or custom only to replace the defaults for this
+                client.
               </div>
-              <ol className="list-decimal space-y-1 pl-5">
-                {displayedIceServers.map((server) => {
-                  const serverKey = `${formatIceServerUrls(server)}-${server.username ?? ''}-${String(server.credential ?? '')}`;
-                  const isDefault = defaultIceServers.some(
-                    (defaultServer) =>
-                      formatIceServerUrls(defaultServer) ===
-                        formatIceServerUrls(server) &&
-                      defaultServer.username === server.username &&
-                      defaultServer.credential === server.credential,
-                  );
-
-                  return (
-                    <li key={serverKey}>
-                      <span className="font-mono">
-                        {formatIceServerUrls(server)}
-                      </span>
-                      {formatIceServerCredentials(server)}
-                      <span className="ml-2 text-xs text-muted-foreground">
-                        {isDefault ? 'default' : 'custom'}
-                      </span>
-                    </li>
-                  );
-                })}
-              </ol>
+              <div className="grid gap-4 md:grid-cols-2">
+                <IceServerList
+                  title={`SDK defaults (${defaultIceServers.length})`}
+                  servers={defaultIceServers}
+                />
+                <IceServerList
+                  title={`Custom from UI (${customIceServers.length})`}
+                  servers={customIceServers}
+                  emptyMessage="No custom STUN/TURN servers added"
+                />
+              </div>
+              <div className="mt-4 border-t pt-3">
+                <IceServerList
+                  title={`Effective ${watchedIceServersMode === 'replace' ? 'custom-only' : 'merged'} list sent to the SDK (${displayedIceServers.length})`}
+                  servers={displayedIceServers}
+                />
+              </div>
             </div>
             <FormField
               control={form.control}

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -16,7 +16,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { ExternalLinkIcon } from 'lucide-react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { Button } from './ui/button';
 
 import {
@@ -31,38 +31,32 @@ import { useClientOptions, useClientProfiles } from '@/atoms/clientOptions';
 import { LoginMethod, useLoginMethod } from '@/atoms/loginMethod';
 import { useConnectionStatus, useTelnyxSdkClient } from '@/atoms/telnyxClient';
 import { Input } from '@/components/ui/input';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import FileUploadButton from './FileUploadButton';
 import { Label } from './ui/label';
 import { RadioGroup, RadioGroupItem } from './ui/radio-group';
 import { Switch } from './ui/switch';
 import { IClientOptionsDemo } from '@/lib/types';
+import {
+  configureIceServers,
+  getCustomIceServers,
+  getDefaultIceServers,
+  getDisplayedIceServers,
+} from '@/lib/iceServers';
 import { TurnServersFormField } from './TurnServersFormField';
 import { StunServersFormField } from './StunServersFormField';
 import { IS_DEV_ENV } from '@/lib/vite';
 
-const configureIceServers = (
-  stunServers: IClientOptionsDemo['stunServers'],
-  turnServers: IClientOptionsDemo['turnServers'],
-): IClientOptionsDemo['iceServers'] => {
-  const iceServers: RTCIceServer[] = [];
+const formatIceServerUrls = (server: RTCIceServer) =>
+  Array.isArray(server.urls) ? server.urls.join(', ') : server.urls;
 
-  if (stunServers) {
-    iceServers.push(
-      ...stunServers.filter(Boolean).map((value) => ({ urls: value })),
-    );
+const formatIceServerCredentials = (server: RTCIceServer) => {
+  if (!server.username && !server.credential) {
+    return '';
   }
 
-  if (turnServers && turnServers.urls) {
-    iceServers.push({
-      urls: turnServers.urls,
-      username: turnServers.username,
-      credential: turnServers.password,
-    });
-  }
-
-  return iceServers.length > 0 ? iceServers : undefined;
+  return ` (${server.username || 'no username'} / ${server.credential ? 'credential set' : 'no credential'})`;
 };
 
 const ClientOptions = () => {
@@ -84,6 +78,7 @@ const ClientOptions = () => {
       forceRelayCandidate: false,
       trickleIce: false,
       singleInterfaceIce: false,
+      iceServersMode: 'merge',
       hangupOnBeforeUnload: true,
       useCanaryRtcServer: false,
       skipTrailing: false,
@@ -101,6 +96,27 @@ const ClientOptions = () => {
     },
   });
 
+  const [watchedStunServers, watchedTurnServers, watchedIceServersMode] =
+    useWatch({
+      control: form.control,
+      name: ['stunServers', 'turnServers', 'iceServersMode'],
+    });
+
+  const defaultIceServers = useMemo(() => getDefaultIceServers(), []);
+  const customIceServers = useMemo(
+    () => getCustomIceServers(watchedStunServers, watchedTurnServers),
+    [watchedStunServers, watchedTurnServers],
+  );
+  const displayedIceServers = useMemo(
+    () =>
+      getDisplayedIceServers(
+        watchedStunServers,
+        watchedTurnServers,
+        watchedIceServersMode,
+      ),
+    [watchedIceServersMode, watchedStunServers, watchedTurnServers],
+  );
+
   const setLoginMethod = useCallback(
     (method: string) => {
       form.setValue('login_token', '');
@@ -117,6 +133,7 @@ const ClientOptions = () => {
     values.iceServers = configureIceServers(
       values.stunServers,
       values.turnServers,
+      values.iceServersMode,
     );
 
     setClientOptions(values);
@@ -427,6 +444,82 @@ const ClientOptions = () => {
               name="turnServers"
               wrapperClassName="mb-4"
             />
+            <FormField
+              control={form.control}
+              name="iceServersMode"
+              render={({ field }) => (
+                <FormItem className="mb-4">
+                  <FormLabel>ICE Server Handling</FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      value={field.value ?? 'merge'}
+                      className="flex flex-col gap-2 md:flex-row md:gap-6"
+                      onValueChange={field.onChange}
+                    >
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem
+                          value="merge"
+                          id="radio-ice-merge"
+                          data-testid="radio-ice-merge"
+                        />
+                        <Label htmlFor="radio-ice-merge">
+                          Merge defaults + custom
+                        </Label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem
+                          value="replace"
+                          id="radio-ice-replace"
+                          data-testid="radio-ice-replace"
+                        />
+                        <Label htmlFor="radio-ice-replace">
+                          Use custom only
+                        </Label>
+                      </div>
+                    </RadioGroup>
+                  </FormControl>
+                  <FormDescription>
+                    Merge keeps the SDK default Telnyx/Google STUN and Telnyx
+                    TURN servers, then appends the STUN/TURN entries above.
+                    Custom only passes exactly the UI-provided entries.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="mb-4 rounded-md border p-3 text-sm">
+              <div className="mb-2 font-medium">Effective ICE servers</div>
+              <div className="mb-2 text-muted-foreground">
+                SDK defaults ({IS_DEV_ENV ? 'development' : 'production'}):{' '}
+                {defaultIceServers.length}. Custom added:{' '}
+                {customIceServers.length}. Effective:{' '}
+                {displayedIceServers.length}.
+              </div>
+              <ol className="list-decimal space-y-1 pl-5">
+                {displayedIceServers.map((server) => {
+                  const serverKey = `${formatIceServerUrls(server)}-${server.username ?? ''}-${String(server.credential ?? '')}`;
+                  const isDefault = defaultIceServers.some(
+                    (defaultServer) =>
+                      formatIceServerUrls(defaultServer) ===
+                        formatIceServerUrls(server) &&
+                      defaultServer.username === server.username &&
+                      defaultServer.credential === server.credential,
+                  );
+
+                  return (
+                    <li key={serverKey}>
+                      <span className="font-mono">
+                        {formatIceServerUrls(server)}
+                      </span>
+                      {formatIceServerCredentials(server)}
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        {isDefault ? 'default' : 'custom'}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ol>
+            </div>
             <FormField
               control={form.control}
               name="trickleIce"

--- a/src/lib/iceServers.ts
+++ b/src/lib/iceServers.ts
@@ -1,0 +1,140 @@
+import { IS_DEV_ENV } from './vite';
+import { IClientOptionsDemo, IceServersMode, TurnServer } from './types';
+
+// Mirrors @telnyx/webrtc defaults from
+// packages/js/src/Modules/Verto/util/constants/index.ts.
+const GOOGLE_STUN_SERVER: RTCIceServer = {
+  urls: 'stun:stun.l.google.com:19302',
+};
+const STUN_SERVER: RTCIceServer = { urls: 'stun:stun.telnyx.com:3478' };
+const STUN_DEV_SERVER: RTCIceServer = { urls: 'stun:stundev.telnyx.com:3478' };
+const TURN_SERVER: RTCIceServer[] = [
+  {
+    urls: 'turn:turn.telnyx.com:3478?transport=udp',
+    username: 'testuser',
+    credential: 'testpassword',
+  },
+  {
+    urls: 'turn:turn.telnyx.com:3478?transport=tcp',
+    username: 'testuser',
+    credential: 'testpassword',
+  },
+];
+const TURN_DEV_SERVER: RTCIceServer[] = [
+  {
+    urls: 'turn:turndev.telnyx.com:3478?transport=udp',
+    username: 'testuser',
+    credential: 'testpassword',
+  },
+  {
+    urls: 'turn:turndev.telnyx.com:3478?transport=tcp',
+    username: 'testuser',
+    credential: 'testpassword',
+  },
+];
+
+export const DEFAULT_PROD_ICE_SERVERS: RTCIceServer[] = [
+  STUN_SERVER,
+  GOOGLE_STUN_SERVER,
+  ...TURN_SERVER,
+];
+
+export const DEFAULT_DEV_ICE_SERVERS: RTCIceServer[] = [
+  STUN_DEV_SERVER,
+  GOOGLE_STUN_SERVER,
+  ...TURN_DEV_SERVER,
+];
+
+export const getDefaultIceServers = (isDev = IS_DEV_ENV): RTCIceServer[] =>
+  isDev ? DEFAULT_DEV_ICE_SERVERS : DEFAULT_PROD_ICE_SERVERS;
+
+const normalizeStunServers = (
+  stunServers: IClientOptionsDemo['stunServers'],
+): RTCIceServer[] =>
+  (stunServers ?? [])
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => ({ urls: value }));
+
+const normalizeTurnServer = (turnServer?: TurnServer): RTCIceServer[] => {
+  const urls = turnServer?.urls?.trim();
+
+  if (!urls) {
+    return [];
+  }
+
+  return [
+    {
+      urls,
+      username: turnServer?.username?.trim() || undefined,
+      credential: turnServer?.password || undefined,
+    },
+  ];
+};
+
+export const getCustomIceServers = (
+  stunServers: IClientOptionsDemo['stunServers'],
+  turnServers: IClientOptionsDemo['turnServers'],
+): RTCIceServer[] => [
+  ...normalizeStunServers(stunServers),
+  ...normalizeTurnServer(turnServers),
+];
+
+const iceServerKey = (server: RTCIceServer) =>
+  JSON.stringify({
+    urls: Array.isArray(server.urls) ? server.urls : [server.urls],
+    username: server.username ?? '',
+    credential: server.credential ?? '',
+  });
+
+export const dedupeIceServers = (
+  iceServers: RTCIceServer[],
+): RTCIceServer[] => {
+  const seen = new Set<string>();
+
+  return iceServers.filter((server) => {
+    const key = iceServerKey(server);
+
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+};
+
+export const configureIceServers = (
+  stunServers: IClientOptionsDemo['stunServers'],
+  turnServers: IClientOptionsDemo['turnServers'],
+  mode: IceServersMode = 'merge',
+): IClientOptionsDemo['iceServers'] => {
+  const customIceServers = getCustomIceServers(stunServers, turnServers);
+
+  if (customIceServers.length === 0) {
+    // Let the SDK apply its environment-specific defaults internally.
+    return undefined;
+  }
+
+  if (mode === 'replace') {
+    return customIceServers;
+  }
+
+  return dedupeIceServers([...getDefaultIceServers(), ...customIceServers]);
+};
+
+export const getDisplayedIceServers = (
+  stunServers: IClientOptionsDemo['stunServers'],
+  turnServers: IClientOptionsDemo['turnServers'],
+  mode: IceServersMode = 'merge',
+): RTCIceServer[] => {
+  const customIceServers = getCustomIceServers(stunServers, turnServers);
+
+  if (customIceServers.length === 0) {
+    return getDefaultIceServers();
+  }
+
+  return mode === 'replace'
+    ? customIceServers
+    : dedupeIceServers([...getDefaultIceServers(), ...customIceServers]);
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,7 @@
 import { IClientOptions } from '@telnyx/webrtc';
 
+export type IceServersMode = 'merge' | 'replace';
+
 export interface IClientOptionsDemo extends IClientOptions {
   rtcIp?: string;
   rtcPort?: number;
@@ -10,6 +12,7 @@ export interface IClientOptionsDemo extends IClientOptions {
   hangupOnBeforeUnload?: boolean;
   stunServers?: string[];
   turnServers?: TurnServer;
+  iceServersMode?: IceServersMode;
   video?: boolean;
   skipTrailing?: boolean;
 }


### PR DESCRIPTION
## Summary
- add merge/replace handling for custom STUN/TURN servers
- mirror @telnyx/webrtc default prod/dev ICE servers in the demo UI
- show effective ICE server preview with default/custom labels

## Validation
- yarn eslint src/components/ClientOptions.tsx src/lib/iceServers.ts src/lib/types.ts src/atoms/clientOptions.ts src/atoms/telnyxClient.ts
- yarn build:production