### PR TITLE
feat: add opt-in enableCallRecording client option

### DIFF
--- a/src/atoms/clientOptions.ts
+++ b/src/atoms/clientOptions.ts
@@ -20,6 +20,7 @@ const clientOptionsDefault: IClientOptionsDemo = {
   skipTrailing: false,
   mutedMicOnStart: false,
   enableCallReports: true,
+  enableCallRecording: false,
   mediaPermissionsRecovery: {
     enabled: true,
     timeout: 20000,

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -119,6 +119,7 @@ const ClientOptions = () => {
       rtcPort: undefined,
       mutedMicOnStart: false,
       enableCallReports: true,
+      enableCallRecording: false,
       video: false,
       anonymous_login: {
         target_type: '',
@@ -778,6 +779,29 @@ const ClientOptions = () => {
                     <Switch
                       data-testid="switch-call-reports"
                       checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="enableCallRecording"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between mb-4">
+                  <div>
+                    <FormLabel>Call Recording</FormLabel>
+                    <FormDescription>
+                      Record calls made with the SDK. Opt-in — off by default.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      data-testid="switch-call-recording"
+                      checked={field.value ?? false}
                       onCheckedChange={field.onChange}
                     />
                   </FormControl>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,10 @@ export interface IClientOptionsDemo extends IClientOptions {
   iceServersMode?: IceServersMode;
   video?: boolean;
   skipTrailing?: boolean;
+  // Opt-in call recording. Defaults to false — recording must be explicitly
+  // enabled. TODO: remove when enableCallRecording is added to IClientOptions
+  // in @telnyx/webrtc.
+  enableCallRecording?: boolean;
 }
 
 export type TurnServer = {


### PR DESCRIPTION
Adds an **`enableCallRecording`** client option to the demo.

- **Defaults to `false`** — recording is opt-in and must be explicitly enabled (`enableCallRecording: true`).
- Surfaced as a **"Call Recording"** toggle in Client Options (mirrors the existing "Call Reports" toggle).
- Wired through: `IClientOptionsDemo` type, the persisted `clientOptions` atom default, the `ClientOptions` form `defaultValues` + field, and the `TelnyxRTC` constructor (client options are spread in).

Note: `enableCallRecording` isn't in `@telnyx/webrtc`'s `IClientOptions` yet, so it's declared on the demo's `IClientOptionsDemo` extension (with a TODO to drop once the SDK adds it). Passing it through is a no-op on the current SDK and activates once SDK support lands.

`tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)