### PR TITLE
chore: bump @telnyx/webrtc to 2.27.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.3",
+    "@telnyx/webrtc": "2.27.4",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.3":
-  version "2.27.3"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.3.tgz#2b58a6940a5e3b63c5d8775d9dfd2893ae3493fe"
-  integrity sha512-fyBbKuaWpRQhLbvZMRk3HVA7bdV6o5UbAniPqAqPZtZqc8zKbyLKQrwkgmIHs7g1bM+k83i9ye15uIHIFfytCw==
+"@telnyx/webrtc@2.27.4":
+  version "2.27.4"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.4.tgz#7925cba73c50cb162daa581302109fe4b1ca6412"
+  integrity sha512-HDUtnPVhj96dnXjZ4KUL3B0UdQVeBsUvrixMounM+hbVioCv5iVM5KlADDGuZG7nrxmHJMOebe4psKPaW2ICWw==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
Bumps `@telnyx/webrtc` from `2.27.3` → `2.27.4` (now published as npm `latest`).

Only `package.json` and the `@telnyx/webrtc` entry in `yarn.lock` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)