### PR TITLE
feat: add simultaneous web/mobile ringing option

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.4",
+    "@telnyx/webrtc": "2.27.5-beta.0",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/atoms/clientOptions.ts
+++ b/src/atoms/clientOptions.ts
@@ -9,6 +9,7 @@ const clientOptionsDefault: IClientOptionsDemo = {
   login: '',
   password: '',
   login_token: '',
+  pushWhenActive: false,
   prefetchIceCandidates: false,
   forceRelayCandidate: false,
   trickleIce: false,

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -105,6 +105,7 @@ const ClientOptions = () => {
       login: '',
       password: '',
       login_token: '',
+      pushWhenActive: false,
       prefetchIceCandidates: false,
       forceRelayCandidate: false,
       trickleIce: false,
@@ -415,6 +416,32 @@ const ClientOptions = () => {
               </div>
             </RadioGroup>
             {loginMethodForm()}
+            {loginMethod !== 'anonymous' && (
+              <FormField
+                control={form.control}
+                name="pushWhenActive"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between mb-4">
+                    <div>
+                      <FormLabel>Simultaneous Web/Mobile Ringing</FormLabel>
+                      <FormDescription>
+                        Allow this credential&apos;s mobile push targets to ring
+                        while the browser is active. Applies on
+                        Connect/Reconnect; the browser is not a push target.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        data-testid="switch-push-when-active"
+                        checked={field.value ?? false}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
             <FormField
               control={form.control}
               name="debug"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,7 @@ export interface IClientOptionsDemo extends IClientOptions {
   // enabled. TODO: remove when enableCallRecording is added to IClientOptions
   // in @telnyx/webrtc.
   enableCallRecording?: boolean;
+  pushWhenActive?: boolean;
 }
 
 export type TurnServer = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.4":
-  version "2.27.4"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.4.tgz#7925cba73c50cb162daa581302109fe4b1ca6412"
-  integrity sha512-HDUtnPVhj96dnXjZ4KUL3B0UdQVeBsUvrixMounM+hbVioCv5iVM5KlADDGuZG7nrxmHJMOebe4psKPaW2ICWw==
+"@telnyx/webrtc@2.27.5-beta.0":
+  version "2.27.5-beta.0"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.5-beta.0.tgz#efe19974b47a61b9e9101eb96eba580d6b7f7d28"
+  integrity sha512-eJJcsxjXBUH9IoTdIYuVPdF4+bXH48StZ41DmRH5cSwrwDMN8zdkLWTXax0uIS9eeaJDLIj/Ug7Ij8l0yfgwOA==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary

- add a persisted **Simultaneous Web/Mobile Ringing** switch, defaulting to off
- show it for password and token authentication; hide it for anonymous AI login
- preserve legacy saved profiles with `field.value ?? false`
- pass `pushWhenActive` directly through the existing client-options path; the SDK owns login serialization

## Verification

- scoped Prettier/ESLint — passed
- `yarn build:development` — passed
- production build — passed
- `git diff --check` — passed

Repository-wide lint has four unrelated pre-existing errors in unchanged files.

## Dependencies

- SDK beta: `@telnyx/webrtc@2.27.5-beta.0`
- SDK support: team-telnyx/webrtc#735
- Backend behavior: team-telnyx/mod_telnyx_rtc#227 (`TELCORE-256`)
- Linear: [VSUP-130](https://linear.app/telnyx/issue/VSUP-130/add-push_when_active-option-for-simultaneous-webmobile-ringing)

