### PR TITLE
feat: add SOUTH-ASIA to the region selector (VSDK-82)

### DIFF
--- a/src/components/RegionSelect.tsx
+++ b/src/components/RegionSelect.tsx
@@ -22,6 +22,7 @@ const RegionSelect = () => {
         <SelectItem value="us-west">US-WEST</SelectItem>
         <SelectItem value="ca-central">CA-CENTRAL</SelectItem>
         <SelectItem value="apac">APAC</SelectItem>
+        <SelectItem value="south-asia">SOUTH-ASIA</SelectItem>
       </SelectContent>
     </Select>
   );


### PR DESCRIPTION
Adds `SOUTH-ASIA` to the region dropdown in the demo.

Ref: [VSDK-82](https://linear.app/telnyx/issue/VSDK-82/add-vsp-instance-in-cn1-prod), [VSDK-221](https://linear.app/telnyx/issue/VSDK-221/investigate-inconsistent-dns-responses-for-turn2telnyxcom-converted-to)

## Why

CN1 (Chennai) was split out of the `apac` region into its own `south-asia` region ([ansible#2334](https://github.com/team-telnyx/ansible/pull/2334)). CN1 measured ~252 ms from Australia, so it did not belong in the same pool as SY1 (Sydney).

The SDK derives the signalling host from the region — `Connection.ts` does `host.replace(/rtc(dev)?/, ` + "`" + `${region}.rtc$1` + "`" + `)` — so selecting `south-asia` points the client at `south-asia.rtc.telnyx.com`.

## ⚠️ Depends on DNS

`south-asia.rtc.telnyx.com` does **not** resolve yet. It needs:
1. a CN1 VSP registered with `SERVICE_5021_REGIONAL_SUBDOMAIN=south-asia.rtc` (ansible#2334 deployed — not done yet), and
2. the public CNAME added in `infra-svc-telnyx-public-domain-records/ns1_telnyx_com.tf` (one `ns1_record` per region; no `south_asia_rtc_telnyx_com` exists yet).

Until both land, selecting SOUTH-ASIA will fail to connect. This is a demo-only UI change and is safe to merge ahead of the DNS work, but the option won't be usable until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)