### PR TITLE
fix: clarify push when active demo option

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.5-beta.0",
+    "@telnyx/webrtc": "2.27.5",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -423,11 +423,14 @@ const ClientOptions = () => {
                 render={({ field }) => (
                   <FormItem className="flex items-center justify-between mb-4">
                     <div>
-                      <FormLabel>Simultaneous Web/Mobile Ringing</FormLabel>
+                      <FormLabel>
+                        Mobile Push Notifications While Web Client Is Active
+                      </FormLabel>
                       <FormDescription>
-                        Allow this credential&apos;s mobile push targets to ring
-                        while the browser is active. Applies on
-                        Connect/Reconnect; the browser is not a push target.
+                        Send push notifications to registered mobile apps even
+                        when this credential has an active connected web client.
+                        Disabled by default; when off, the server does not send
+                        mobile push while the web client is connected.
                       </FormDescription>
                     </div>
                     <FormControl>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.5-beta.0":
-  version "2.27.5-beta.0"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.5-beta.0.tgz#efe19974b47a61b9e9101eb96eba580d6b7f7d28"
-  integrity sha512-eJJcsxjXBUH9IoTdIYuVPdF4+bXH48StZ41DmRH5cSwrwDMN8zdkLWTXax0uIS9eeaJDLIj/Ug7Ij8l0yfgwOA==
+"@telnyx/webrtc@2.27.5":
+  version "2.27.5"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.5.tgz#52e34be03317e964ce9f74fdaf357e90be32cbaa"
+  integrity sha512-i7b1XEX9GIescGntumFIkJiD3F3nc9HYebKpkxj1U0DgHlE2rqKlGUazBWBsC/2tdQ7JlbQR2rA/EumRn7V9YA==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary

* promote `@telnyx/webrtc` from `2.27.5-beta.0` to stable `2.27.5`
* replace the misleading simultaneous-ringing label with mobile-push-specific copy
* document that mobile push remains enabled alongside an active web client only when opted in; the option defaults off
* keep the existing direct `pushWhenActive` client-options path unchanged

## Verification

* `yarn eslint src/components/ClientOptions.tsx` — passed
* `yarn build:development` — passed
* `yarn build:production` — passed
* `git diff --check` — passed

Builds retain existing non-fatal Browserslist, dynamic-import, and chunk-size warnings.

## References

* [VSDK-437](https://linear.app/telnyx/issue/VSDK-437/demo-upgrade-webrtc-sdk-to-2275-and-clarify-push-when-active-copy)
* [WebRTC 2.27.5](<https://github.com/team-telnyx/webrtc/releases/tag/webrtc%2Fv2.27.5>)
* [SDK implementation](<https://github.com/team-telnyx/webrtc/pull/735>)