### PR TITLE
feat: include TURNS in ICE server UI

### DIFF
--- a/src/components/TurnServersFormField.tsx
+++ b/src/components/TurnServersFormField.tsx
@@ -45,18 +45,18 @@ export function TurnServersFormField<
           <div className={props.wrapperClassName}>
             <div className="grid md:grid-cols-3 gap-4 mb-1">
               <FormItem>
-                <FormLabel>TURN Server URL</FormLabel>
+                <FormLabel>TURN/TURNS Server URL</FormLabel>
                 <FormControl>
                   <Input
                     data-testid="input-turn-server-url"
-                    placeholder="turn:turn.telnyx.com:3478?transport=tcp"
+                    placeholder="turns:turn.telnyx.com:443"
                     value={(turnServer?.urls as string) ?? ''}
                     onChange={(e) => updateTurnServer('urls', e.target.value)}
                   />
                 </FormControl>
               </FormItem>
               <FormItem>
-                <FormLabel>TURN Username</FormLabel>
+                <FormLabel>TURN/TURNS Username</FormLabel>
                 <FormControl>
                   <Input
                     data-testid="input-turn-username"
@@ -69,7 +69,7 @@ export function TurnServersFormField<
                 </FormControl>
               </FormItem>
               <FormItem>
-                <FormLabel>TURN Password</FormLabel>
+                <FormLabel>TURN/TURNS Password</FormLabel>
                 <FormControl>
                   <Input
                     data-testid="input-turn-password"

--- a/src/lib/iceServers.ts
+++ b/src/lib/iceServers.ts
@@ -19,6 +19,16 @@ const TURN_SERVER: RTCIceServer[] = [
     username: 'testuser',
     credential: 'testpassword',
   },
+  {
+    urls: 'turns:turn.telnyx.com:443',
+    username: 'testuser',
+    credential: 'testpassword',
+  },
+  {
+    urls: 'turns:turn2.telnyx.com:443',
+    username: 'testuser',
+    credential: 'testpassword',
+  },
 ];
 const TURN_DEV_SERVER: RTCIceServer[] = [
   {
@@ -28,6 +38,11 @@ const TURN_DEV_SERVER: RTCIceServer[] = [
   },
   {
     urls: 'turn:turndev.telnyx.com:3478?transport=tcp',
+    username: 'testuser',
+    credential: 'testpassword',
+  },
+  {
+    urls: 'turns:turndev.telnyx.com:443',
     username: 'testuser',
     credential: 'testpassword',
   },


### PR DESCRIPTION
## Summary
- Confirmed latest `@telnyx/webrtc` default ICE server list includes TURN over TLS (`turns:`) entries.
- Updated demo ICE server preview defaults to include prod `turns:turn.telnyx.com:443` and `turns:turn2.telnyx.com:443`.
- Updated dev defaults to include `turns:turndev.telnyx.com:443`.
- Updated custom TURN field labels/placeholder to make TURNS explicit.

## Note on `turn2`
Leaving `turns:turn2.telnyx.com:443` in the production default preview/merge list is intentional. The SDK still ships it as part of the production default ICE list, and the demo's merge mode passes this locally constructed list to the SDK whenever a user adds custom ICE servers. Keeping `turn2` avoids silently dropping an SDK fallback during the DNS migration.

## Validation
- ✅ Verified installed `@telnyx/webrtc@2.27.7` contains the expected `turns:` defaults.
- ✅ Verified latest npm `@telnyx/webrtc@2.27.8` tarball contains the expected `turns:` defaults.
- ✅ `yarn eslint src/lib/iceServers.ts src/components/TurnServersFormField.tsx`
- ✅ `yarn build:development`
- ⚠️ `yarn lint` remains red on existing React hook lint errors outside this patch.
