### PR TITLE
feat: add tri-state canary routing control

### DIFF
--- a/src/atoms/clientOptions.ts
+++ b/src/atoms/clientOptions.ts
@@ -17,7 +17,6 @@ const clientOptionsDefault: IClientOptionsDemo = {
   iceServersMode: 'merge',
   keepConnectionAliveOnSocketClose: false,
   hangupOnBeforeUnload: true,
-  useCanaryRtcServer: false,
   skipTrailing: false,
   mutedMicOnStart: false,
   enableCallReports: true,

--- a/src/components/ClientOptions.tsx
+++ b/src/components/ClientOptions.tsx
@@ -112,7 +112,6 @@ const ClientOptions = () => {
       singleInterfaceIce: false,
       iceServersMode: 'merge',
       hangupOnBeforeUnload: true,
-      useCanaryRtcServer: false,
       skipTrailing: false,
       ringbackFile: '/ringback.mp3',
       ringtoneFile: '/ringtone.mp3',
@@ -163,14 +162,21 @@ const ClientOptions = () => {
   );
 
   const onSubmit = (values: Partial<IClientOptionsDemo>) => {
-    values.iceServers = configureIceServers(
-      values.stunServers,
-      values.turnServers,
-      values.iceServersMode,
-    );
+    const normalizedValues = {
+      ...values,
+      iceServers: configureIceServers(
+        values.stunServers,
+        values.turnServers,
+        values.iceServersMode,
+      ),
+    };
 
-    setClientOptions(values);
-    onSaveProfile(values);
+    if (normalizedValues.useCanaryRtcServer === undefined) {
+      delete normalizedValues.useCanaryRtcServer;
+    }
+
+    setClientOptions(normalizedValues);
+    onSaveProfile(normalizedValues);
   };
 
   const onSaveProfile = (values: Partial<IClientOptionsDemo>) => {
@@ -552,8 +558,8 @@ const ClientOptions = () => {
             <div className="mb-4 rounded-md border p-3 text-sm">
               <div className="mb-2 font-medium">ICE server preview</div>
               <div className="mb-3 text-muted-foreground">
-                Defaults are the SDK {IS_DEV_ENV ? 'development' : 'production'}
-                {' '}ICE servers. Choose merge to append custom entries to the
+                Defaults are the SDK {IS_DEV_ENV ? 'development' : 'production'}{' '}
+                ICE servers. Choose merge to append custom entries to the
                 defaults, or custom only to replace the defaults for this
                 client.
               </div>
@@ -725,22 +731,59 @@ const ClientOptions = () => {
               control={form.control}
               name="useCanaryRtcServer"
               render={({ field }) => (
-                <FormItem className="flex items-center mb-4 justify-between">
-                  <div>
-                    <FormLabel>Canary RTC Server</FormLabel>
-                    <FormDescription>
-                      Outgoing and incoming call flows using the Canary RTC
-                      Server.
-                    </FormDescription>
-                  </div>
+                <FormItem className="mb-4">
+                  <FormLabel id="canary-rtc-server-label">
+                    Canary RTC Server
+                  </FormLabel>
                   <FormControl>
-                    <Switch
-                      data-testid="switch-canary-rtc-server"
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
+                    <RadioGroup
+                      aria-labelledby="canary-rtc-server-label"
+                      value={
+                        field.value === undefined
+                          ? 'unset'
+                          : field.value
+                            ? 'enabled'
+                            : 'disabled'
+                      }
+                      className="flex flex-col gap-2 md:flex-row md:gap-6"
+                      onValueChange={(value) =>
+                        field.onChange(
+                          value === 'unset' ? undefined : value === 'enabled',
+                        )
+                      }
+                    >
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem
+                          value="enabled"
+                          id="radio-canary-enabled"
+                          data-testid="switch-canary-rtc-server"
+                        />
+                        <Label htmlFor="radio-canary-enabled">Enabled</Label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem
+                          value="disabled"
+                          id="radio-canary-disabled"
+                          data-testid="radio-canary-disabled"
+                        />
+                        <Label htmlFor="radio-canary-disabled">Disabled</Label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem
+                          value="unset"
+                          id="radio-canary-unset"
+                          data-testid="radio-canary-unset"
+                        />
+                        <Label htmlFor="radio-canary-unset">
+                          Unset (SDK default)
+                        </Label>
+                      </div>
+                    </RadioGroup>
                   </FormControl>
-
+                  <FormDescription>
+                    Explicitly enable or disable Canary RTC Server routing, or
+                    leave the option unset for VSP's default routing.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -754,9 +797,8 @@ const ClientOptions = () => {
                   <div>
                     <FormLabel>Skip Trailing</FormLabel>
                     <FormDescription>
-                      Skip VSP pre-routing identity resolution (trailing
-                      release routing). Intended for internal/test-infra
-                      usage only.
+                      Skip VSP pre-routing identity resolution (trailing release
+                      routing). Intended for internal/test-infra usage only.
                     </FormDescription>
                   </div>
                   <FormControl>


### PR DESCRIPTION
## Summary
- replaces the Canary RTC Server switch with `Enabled`, `Disabled`, and `Unset` choices
- persists/passes enabled as `true` and disabled as `false`
- removes `useCanaryRtcServer` from submitted client options when unset
- preserves legacy saved `true`/`false` profiles and keeps profiles without the field unset
- preserves the existing BBT selector on the Enabled option

## Dependencies
- VSP routing toggle: https://github.com/team-telnyx/voice-sdk-proxy/pull/166
- SDK companion PR: https://github.com/team-telnyx/webrtc/pull/756

## Verification
- [x] Scoped ESLint
- [x] Scoped Prettier check
- [x] TypeScript project build
- [x] Development build
- [x] Production build
- [x] `git diff --check`
- [x] Independent review passed

## Notes
This repository has no test runner or tracked component tests. Both builds pass with the existing Vite dynamic-import and chunk-size warnings.
