### PR TITLE
chore: bump @telnyx/webrtc to 2.27.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@rive-app/react-canvas-lite": "^4.16.7",
     "@telnyx/rtc-sipjs-simple-user": "^0.0.8",
-    "@telnyx/webrtc": "2.27.7",
+    "@telnyx/webrtc": "2.27.9",
     "@types/lodash-es": "^4.17.12",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@
     babel-runtime "^6.26.0"
     sip.js "0.21.2"
 
-"@telnyx/webrtc@2.27.7":
-  version "2.27.7"
-  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.7.tgz#64ef0f6b22925a4e24a79b412bf0c55501a4bfd0"
-  integrity sha512-uVMJUqNm5xorn5a+rqtYMsXdM19RaG4vCIBbMJCY3ESe8LaOfB1KXbsMnu4CtxUMcr/ESERewXteDlDfkWouWQ==
+"@telnyx/webrtc@2.27.9":
+  version "2.27.9"
+  resolved "https://registry.yarnpkg.com/@telnyx/webrtc/-/webrtc-2.27.9.tgz#3a06e06d4f154b527279f0ff9e3b739456800db8"
+  integrity sha512-4ZUY6K7tWdKewrUTFiajFQicmPIriSq2tkHmL0xHFhzRAKAD/sHD8hizHbOmGKFUQYLHXItzSmxVF844undgWQ==
   dependencies:
     "@peermetrics/webrtc-stats" "^5.7.1"
     loglevel "^1.6.8"


### PR DESCRIPTION
## Summary

Bumps the `@telnyx/webrtc` dependency from `2.27.7` → `2.27.9` (the latest production release of the WebRTC JS SDK).

### What changed in the SDK (2.27.7 → 2.27.9)

**Features**
- `Region` constant exported from the package entry point (7 supported signaling regions)
- `sendAIConversationMessage()` accepts `response.audio_stream.subscribe` outbound items

**Bug fixes**
- `forceRelayCandidate` preserved across attach recovery and page refresh (VSDK-467)
- Detect a socket that receives but no longer sends (VSUP-171)
- Ignore deferred signaling after hangup

**Refactors**
- Simplified host-only ICE diagnostics
- Removed legacy React Native support (dead-code, non-breaking)

Full changelog: https://github.com/team-telnyx/webrtc/releases/tag/webrtc/v2.27.9

### Verification

- `yarn install` — lockfile updated
- `yarn build:production` — build succeeds (the `SDKVersionDropdown.tsx` dynamic-import warning is pre-existing, unrelated to this bump)

### Files changed

- `package.json` — dependency version `2.27.7` → `2.27.9`
- `yarn.lock` — resolved hash updated